### PR TITLE
feat(query): alias expansion + ontology-metadata query parser (xz4.1.24, xz4.1.25)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"0e43d8f7-0096-48e3-ba7a-69d5b8c6ec6f","pid":1145318,"acquiredAt":1776602098587}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"0e43d8f7-0096-48e3-ba7a-69d5b8c6ec6f","pid":1145318,"acquiredAt":1776602098587}

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ Thumbs.db
 .cache/
 deploy/.env
 CLAUDE.local.md
+.claude/scheduled_tasks.lock

--- a/results/entity_query_expansion/run_2026-04-20.json
+++ b/results/entity_query_expansion/run_2026-04-20.json
@@ -1,0 +1,1546 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-04-20T17:39:35.020050+00:00",
+  "oracle": {
+    "kind": "kitchen_sink_hybrid_top_k",
+    "top_k": 30,
+    "lexical_limit": 200,
+    "include_body": true,
+    "grading": "reciprocal_rank",
+    "note": "Oracle is hybrid_search with both flags ON. Variants are evaluated against the same oracle so wins reflect signal recovery, not entity-id filter membership tautologies."
+  },
+  "limitations": [
+    "Structural benchmark \u2014 does not measure topical relevance.",
+    "Oracle is self-referential (built with both flags ON); it rewards variants that recover the fused-signal top-K, but may under-credit ontology-only wins on queries where the oracle is dominated by alias signals.",
+    "Topical evaluation requires the persona-Claude judge harness (see docs/prd/amendments/2026-04-18-m6-m12-collapse.md)."
+  ],
+  "queries": [
+    {
+      "id": "alias_01",
+      "query": "HST observations of cool brown dwarfs"
+    },
+    {
+      "id": "alias_03",
+      "query": "JWST MIRI mid-infrared imaging of planetary nebulae"
+    },
+    {
+      "id": "alias_05",
+      "query": "CMB anisotropy measurements from WMAP"
+    },
+    {
+      "id": "alias_06",
+      "query": "X-ray binaries detected by Chandra"
+    },
+    {
+      "id": "ontology_01",
+      "query": "M-type asteroid metallic composition from near-infrared spectroscopy"
+    },
+    {
+      "id": "ontology_03",
+      "query": "C-type asteroid water and organics content"
+    },
+    {
+      "id": "ontology_04",
+      "query": "infrared instruments on space telescopes for exoplanet detection"
+    },
+    {
+      "id": "ontology_07",
+      "query": "flagship NASA missions to the outer solar system"
+    },
+    {
+      "id": "mixed_01",
+      "query": "Kepler space telescope exoplanet occurrence statistics"
+    },
+    {
+      "id": "mixed_02",
+      "query": "Cassini spacecraft instruments at Saturn"
+    }
+  ],
+  "summary": {
+    "baseline": {
+      "mean_ndcg_at_10": 0.575,
+      "median_ndcg_at_10": 0.7491,
+      "mean_entity_coverage_top10": 0.0125,
+      "mean_wallclock_ms": 211.25,
+      "n_scored": 10,
+      "n_timeouts": 0,
+      "n_queries_with_entity_pool": 8
+    },
+    "alias": {
+      "mean_ndcg_at_10": 0.5731,
+      "median_ndcg_at_10": 0.7363,
+      "mean_entity_coverage_top10": 0.0125,
+      "mean_wallclock_ms": 3764.08,
+      "n_scored": 10,
+      "n_timeouts": 0,
+      "n_queries_with_entity_pool": 8
+    },
+    "ontology": {
+      "mean_ndcg_at_10": 0.688,
+      "median_ndcg_at_10": 0.9868,
+      "mean_entity_coverage_top10": 0.0125,
+      "mean_wallclock_ms": 138.35,
+      "n_scored": 10,
+      "n_timeouts": 0,
+      "n_queries_with_entity_pool": 8
+    },
+    "both": {
+      "mean_ndcg_at_10": 0.6887,
+      "median_ndcg_at_10": 0.9905,
+      "mean_entity_coverage_top10": 0.0125,
+      "mean_wallclock_ms": 15192.92,
+      "n_scored": 10,
+      "n_timeouts": 0,
+      "n_queries_with_entity_pool": 8
+    }
+  },
+  "per_query": [
+    {
+      "query_id": "alias_01",
+      "query": "HST observations of cool brown dwarfs",
+      "alias_entities_found": [
+        {
+          "id": 8500,
+          "canonical": "RUTGERS/IMCS/COOL",
+          "type": "mission"
+        }
+      ],
+      "ontology_clauses": [],
+      "oracle_size": 30,
+      "entity_linked_pool_size": 20,
+      "variants": {
+        "baseline": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2004A&A...424..213B",
+            "2023arXiv230612363H",
+            "2022ApJ...930...24G",
+            "2008A&A...481..757B",
+            "2019MNRAS.486.2254D",
+            "2015PhDT.......216A",
+            "2005AJ....130.1221D",
+            "1996ApJ...468..655C",
+            "1995ApJ...440..216P",
+            "2017reph.conf30002P"
+          ],
+          "timing_ms": {
+            "lexical_ms": 21.69,
+            "body_lexical_ms": 83.04,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.05,
+            "rerank_ms": 0.0,
+            "total_ms": 104.78,
+            "wallclock_ms": 105.04
+          },
+          "search_metadata": {}
+        },
+        "alias": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2004A&A...424..213B",
+            "2023arXiv230612363H",
+            "2022ApJ...930...24G",
+            "2008A&A...481..757B",
+            "2019MNRAS.486.2254D",
+            "2015PhDT.......216A",
+            "2005AJ....130.1221D",
+            "1996ApJ...468..655C",
+            "1995ApJ...440..216P",
+            "2017reph.conf30002P"
+          ],
+          "timing_ms": {
+            "alias_expansion_ms": 0.04,
+            "lexical_ms": 22.21,
+            "alias_lexical_ms": 114.93,
+            "body_lexical_ms": 91.71,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.07,
+            "rerank_ms": 0.0,
+            "total_ms": 228.96,
+            "wallclock_ms": 229.32
+          },
+          "search_metadata": {
+            "alias_matches": 1,
+            "alias_lanes": 1
+          }
+        },
+        "ontology": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2004A&A...424..213B",
+            "2023arXiv230612363H",
+            "2022ApJ...930...24G",
+            "2008A&A...481..757B",
+            "2019MNRAS.486.2254D",
+            "2015PhDT.......216A",
+            "2005AJ....130.1221D",
+            "1996ApJ...468..655C",
+            "1995ApJ...440..216P",
+            "2017reph.conf30002P"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.02,
+            "lexical_ms": 23.02,
+            "body_lexical_ms": 89.88,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.05,
+            "rerank_ms": 0.0,
+            "total_ms": 112.97,
+            "wallclock_ms": 113.25
+          },
+          "search_metadata": {
+            "ontology_clauses": 0,
+            "ontology_entity_ids": 0
+          }
+        },
+        "both": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2004A&A...424..213B",
+            "2023arXiv230612363H",
+            "2022ApJ...930...24G",
+            "2008A&A...481..757B",
+            "2019MNRAS.486.2254D",
+            "2015PhDT.......216A",
+            "2005AJ....130.1221D",
+            "1996ApJ...468..655C",
+            "1995ApJ...440..216P",
+            "2017reph.conf30002P"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.02,
+            "alias_expansion_ms": 0.04,
+            "lexical_ms": 22.68,
+            "alias_lexical_ms": 120.06,
+            "body_lexical_ms": 90.93,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.06,
+            "rerank_ms": 0.0,
+            "total_ms": 233.79,
+            "wallclock_ms": 234.09
+          },
+          "search_metadata": {
+            "ontology_clauses": 0,
+            "ontology_entity_ids": 0,
+            "alias_matches": 1,
+            "alias_lanes": 1
+          }
+        }
+      }
+    },
+    {
+      "query_id": "alias_03",
+      "query": "JWST MIRI mid-infrared imaging of planetary nebulae",
+      "alias_entities_found": [
+        {
+          "id": 6184,
+          "canonical": "CA/INAC/NAP/MRD/MID",
+          "type": "mission"
+        }
+      ],
+      "ontology_clauses": [],
+      "oracle_size": 30,
+      "entity_linked_pool_size": 70,
+      "variants": {
+        "baseline": {
+          "ndcg_at_10": 0.9061,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2025AJ....169..236R",
+            "2025ApJ...980...49T",
+            "2020AJ....160...28G",
+            "2009PASA...26..415L",
+            "2020arXiv200701603P",
+            "2020arXiv200206693L",
+            "2019arXiv190210541H",
+            "2019astro2020T.504K",
+            "2018ConPh..59..251K",
+            "2018arXiv180909642T"
+          ],
+          "timing_ms": {
+            "lexical_ms": 9.33,
+            "body_lexical_ms": 34.91,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.04,
+            "rerank_ms": 0.0,
+            "total_ms": 44.28,
+            "wallclock_ms": 44.55
+          },
+          "search_metadata": {}
+        },
+        "alias": {
+          "ndcg_at_10": 0.9061,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2025AJ....169..236R",
+            "2025ApJ...980...49T",
+            "2020AJ....160...28G",
+            "2009PASA...26..415L",
+            "2020arXiv200701603P",
+            "2020arXiv200206693L",
+            "2019arXiv190210541H",
+            "2019astro2020T.504K",
+            "2018ConPh..59..251K",
+            "2018arXiv180909642T"
+          ],
+          "timing_ms": {
+            "alias_expansion_ms": 0.06,
+            "lexical_ms": 11.28,
+            "alias_lexical_ms": 113.27,
+            "body_lexical_ms": 32.32,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.03,
+            "rerank_ms": 0.0,
+            "total_ms": 156.96,
+            "wallclock_ms": 157.19
+          },
+          "search_metadata": {
+            "alias_matches": 1,
+            "alias_lanes": 1
+          }
+        },
+        "ontology": {
+          "ndcg_at_10": 0.9061,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2025AJ....169..236R",
+            "2025ApJ...980...49T",
+            "2020AJ....160...28G",
+            "2009PASA...26..415L",
+            "2020arXiv200701603P",
+            "2020arXiv200206693L",
+            "2019arXiv190210541H",
+            "2019astro2020T.504K",
+            "2018ConPh..59..251K",
+            "2018arXiv180909642T"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.02,
+            "lexical_ms": 8.28,
+            "body_lexical_ms": 32.84,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.04,
+            "rerank_ms": 0.0,
+            "total_ms": 41.18,
+            "wallclock_ms": 41.44
+          },
+          "search_metadata": {
+            "ontology_clauses": 0,
+            "ontology_entity_ids": 0
+          }
+        },
+        "both": {
+          "ndcg_at_10": 0.9061,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2025AJ....169..236R",
+            "2025ApJ...980...49T",
+            "2020AJ....160...28G",
+            "2009PASA...26..415L",
+            "2020arXiv200701603P",
+            "2020arXiv200206693L",
+            "2019arXiv190210541H",
+            "2019astro2020T.504K",
+            "2018ConPh..59..251K",
+            "2018arXiv180909642T"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.03,
+            "alias_expansion_ms": 0.06,
+            "lexical_ms": 8.8,
+            "alias_lexical_ms": 106.02,
+            "body_lexical_ms": 31.28,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.03,
+            "rerank_ms": 0.0,
+            "total_ms": 146.22,
+            "wallclock_ms": 146.44
+          },
+          "search_metadata": {
+            "ontology_clauses": 0,
+            "ontology_entity_ids": 0,
+            "alias_matches": 1,
+            "alias_lanes": 1
+          }
+        }
+      }
+    },
+    {
+      "query_id": "alias_05",
+      "query": "CMB anisotropy measurements from WMAP",
+      "alias_entities_found": [
+        {
+          "id": 5977,
+          "canonical": "CMB",
+          "type": "mission"
+        }
+      ],
+      "ontology_clauses": [],
+      "oracle_size": 30,
+      "entity_linked_pool_size": 500,
+      "variants": {
+        "baseline": {
+          "ndcg_at_10": 0.9927,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2006ApJ...645L..89S",
+            "2013IJMPA..2850094D",
+            "2004PhRvD..70l3521C",
+            "2013JCAP...06..026K",
+            "2006NewAR..50..889S",
+            "2015ApJ...810..143A",
+            "2003NewAR..47..741O",
+            "2018PhRvD..98b3521M",
+            "2006JCAP...06..007C",
+            "2011ASPC..449..446A"
+          ],
+          "timing_ms": {
+            "lexical_ms": 13.09,
+            "body_lexical_ms": 96.78,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.06,
+            "rerank_ms": 0.0,
+            "total_ms": 109.93,
+            "wallclock_ms": 110.32
+          },
+          "search_metadata": {}
+        },
+        "alias": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2006ApJ...645L..89S",
+            "2013IJMPA..2850094D",
+            "2004PhRvD..70l3521C",
+            "2013JCAP...06..026K",
+            "2006NewAR..50..889S",
+            "2015ApJ...810..143A",
+            "2012amld.book...55P",
+            "2003NewAR..47..741O",
+            "2018PhRvD..98b3521M",
+            "2006JCAP...06..007C"
+          ],
+          "timing_ms": {
+            "alias_expansion_ms": 0.05,
+            "lexical_ms": 13.59,
+            "alias_lexical_ms": 211.99,
+            "body_lexical_ms": 103.44,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.1,
+            "rerank_ms": 0.0,
+            "total_ms": 329.17,
+            "wallclock_ms": 329.57
+          },
+          "search_metadata": {
+            "alias_matches": 1,
+            "alias_lanes": 1
+          }
+        },
+        "ontology": {
+          "ndcg_at_10": 0.9927,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2006ApJ...645L..89S",
+            "2013IJMPA..2850094D",
+            "2004PhRvD..70l3521C",
+            "2013JCAP...06..026K",
+            "2006NewAR..50..889S",
+            "2015ApJ...810..143A",
+            "2003NewAR..47..741O",
+            "2018PhRvD..98b3521M",
+            "2006JCAP...06..007C",
+            "2011ASPC..449..446A"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.02,
+            "lexical_ms": 14.73,
+            "body_lexical_ms": 98.1,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.06,
+            "rerank_ms": 0.0,
+            "total_ms": 112.91,
+            "wallclock_ms": 113.28
+          },
+          "search_metadata": {
+            "ontology_clauses": 0,
+            "ontology_entity_ids": 0
+          }
+        },
+        "both": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2006ApJ...645L..89S",
+            "2013IJMPA..2850094D",
+            "2004PhRvD..70l3521C",
+            "2013JCAP...06..026K",
+            "2006NewAR..50..889S",
+            "2015ApJ...810..143A",
+            "2012amld.book...55P",
+            "2003NewAR..47..741O",
+            "2018PhRvD..98b3521M",
+            "2006JCAP...06..007C"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.02,
+            "alias_expansion_ms": 0.05,
+            "lexical_ms": 12.86,
+            "alias_lexical_ms": 200.34,
+            "body_lexical_ms": 96.72,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.1,
+            "rerank_ms": 0.0,
+            "total_ms": 310.09,
+            "wallclock_ms": 310.46
+          },
+          "search_metadata": {
+            "ontology_clauses": 0,
+            "ontology_entity_ids": 0,
+            "alias_matches": 1,
+            "alias_lanes": 1
+          }
+        }
+      }
+    },
+    {
+      "query_id": "alias_06",
+      "query": "X-ray binaries detected by Chandra",
+      "alias_entities_found": [],
+      "ontology_clauses": [],
+      "oracle_size": 30,
+      "entity_linked_pool_size": 0,
+      "variants": {
+        "baseline": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": null,
+          "top10": [
+            "2007A&A...471L..63A",
+            "2019RLSFN..30S.125P",
+            "2008MNRAS.383..330M",
+            "2011ApJ...739L..51B",
+            "2006IAUS..230..200S",
+            "2015ApJ...808...19L",
+            "2010ApJ...721.1523K",
+            "2011ApJ...735...95C",
+            "2020ApJ...889...58R",
+            "2014AJ....148...32J"
+          ],
+          "timing_ms": {
+            "lexical_ms": 45.38,
+            "body_lexical_ms": 177.23,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.06,
+            "rerank_ms": 0.0,
+            "total_ms": 222.67,
+            "wallclock_ms": 222.97
+          },
+          "search_metadata": {}
+        },
+        "alias": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": null,
+          "top10": [
+            "2007A&A...471L..63A",
+            "2019RLSFN..30S.125P",
+            "2008MNRAS.383..330M",
+            "2011ApJ...739L..51B",
+            "2006IAUS..230..200S",
+            "2015ApJ...808...19L",
+            "2010ApJ...721.1523K",
+            "2011ApJ...735...95C",
+            "2020ApJ...889...58R",
+            "2014AJ....148...32J"
+          ],
+          "timing_ms": {
+            "alias_expansion_ms": 0.03,
+            "lexical_ms": 45.92,
+            "body_lexical_ms": 197.32,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.08,
+            "rerank_ms": 0.0,
+            "total_ms": 243.35,
+            "wallclock_ms": 243.75
+          },
+          "search_metadata": {
+            "alias_matches": 0,
+            "alias_lanes": 0
+          }
+        },
+        "ontology": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": null,
+          "top10": [
+            "2007A&A...471L..63A",
+            "2019RLSFN..30S.125P",
+            "2008MNRAS.383..330M",
+            "2011ApJ...739L..51B",
+            "2006IAUS..230..200S",
+            "2015ApJ...808...19L",
+            "2010ApJ...721.1523K",
+            "2011ApJ...735...95C",
+            "2020ApJ...889...58R",
+            "2014AJ....148...32J"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.03,
+            "lexical_ms": 49.47,
+            "body_lexical_ms": 215.63,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.07,
+            "rerank_ms": 0.0,
+            "total_ms": 265.2,
+            "wallclock_ms": 265.62
+          },
+          "search_metadata": {
+            "ontology_clauses": 0,
+            "ontology_entity_ids": 0
+          }
+        },
+        "both": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": null,
+          "top10": [
+            "2007A&A...471L..63A",
+            "2019RLSFN..30S.125P",
+            "2008MNRAS.383..330M",
+            "2011ApJ...739L..51B",
+            "2006IAUS..230..200S",
+            "2015ApJ...808...19L",
+            "2010ApJ...721.1523K",
+            "2011ApJ...735...95C",
+            "2020ApJ...889...58R",
+            "2014AJ....148...32J"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.02,
+            "alias_expansion_ms": 0.03,
+            "lexical_ms": 63.67,
+            "body_lexical_ms": 261.8,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.09,
+            "rerank_ms": 0.0,
+            "total_ms": 325.61,
+            "wallclock_ms": 326.14
+          },
+          "search_metadata": {
+            "ontology_clauses": 0,
+            "ontology_entity_ids": 0,
+            "alias_matches": 0,
+            "alias_lanes": 0
+          }
+        }
+      }
+    },
+    {
+      "query_id": "ontology_01",
+      "query": "M-type asteroid metallic composition from near-infrared spectroscopy",
+      "alias_entities_found": [],
+      "ontology_clauses": [
+        {
+          "entity_type": "asteroid",
+          "properties_filter": null,
+          "surface": "asteroid"
+        },
+        {
+          "entity_type": "asteroid",
+          "properties_filter": {
+            "taxonomy": "M"
+          },
+          "surface": "M-type"
+        }
+      ],
+      "oracle_size": 0,
+      "entity_linked_pool_size": 0,
+      "variants": {
+        "baseline": {
+          "ndcg_at_10": 0.0,
+          "entity_coverage_top10": null,
+          "top10": [
+            "2021PSJ.....2...95C",
+            "2014DPS....4650603L",
+            "2020AGUFMP056.0002L",
+            "2020SSRv..216...59B",
+            "2024PSJ.....5..230D",
+            "2023E&SS...1002694D",
+            "2019PASP..131i4501K",
+            "2004eso..pres...21.",
+            "2019MNRAS.486.1292M",
+            "2023A&A...671A..77Z"
+          ],
+          "timing_ms": {
+            "lexical_ms": 45.13,
+            "body_lexical_ms": 158.59,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.06,
+            "rerank_ms": 0.0,
+            "total_ms": 203.78,
+            "wallclock_ms": 204.15
+          },
+          "search_metadata": {}
+        },
+        "alias": {
+          "ndcg_at_10": 0.0,
+          "entity_coverage_top10": null,
+          "top10": [
+            "2021PSJ.....2...95C",
+            "2014DPS....4650603L",
+            "2020AGUFMP056.0002L",
+            "2020SSRv..216...59B",
+            "2024PSJ.....5..230D",
+            "2023E&SS...1002694D",
+            "2019PASP..131i4501K",
+            "2004eso..pres...21.",
+            "2019MNRAS.486.1292M",
+            "2023A&A...671A..77Z"
+          ],
+          "timing_ms": {
+            "alias_expansion_ms": 0.07,
+            "lexical_ms": 43.98,
+            "body_lexical_ms": 140.47,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.06,
+            "rerank_ms": 0.0,
+            "total_ms": 184.58,
+            "wallclock_ms": 184.92
+          },
+          "search_metadata": {
+            "alias_matches": 0,
+            "alias_lanes": 0
+          }
+        },
+        "ontology": {
+          "ndcg_at_10": 0.0,
+          "entity_coverage_top10": null,
+          "top10": [],
+          "timing_ms": {
+            "ontology_parse_ms": 0.45,
+            "lexical_ms": 48.35,
+            "body_lexical_ms": 140.59,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.01,
+            "rerank_ms": 0.0,
+            "total_ms": 189.4,
+            "wallclock_ms": 189.55
+          },
+          "search_metadata": {
+            "ontology_clauses": 2,
+            "ontology_entity_ids": 0
+          }
+        },
+        "both": {
+          "ndcg_at_10": 0.0,
+          "entity_coverage_top10": null,
+          "top10": [],
+          "timing_ms": {
+            "ontology_parse_ms": 0.37,
+            "alias_expansion_ms": 0.05,
+            "lexical_ms": 43.75,
+            "body_lexical_ms": 135.74,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.01,
+            "rerank_ms": 0.0,
+            "total_ms": 179.92,
+            "wallclock_ms": 180.07
+          },
+          "search_metadata": {
+            "ontology_clauses": 2,
+            "ontology_entity_ids": 0,
+            "alias_matches": 0,
+            "alias_lanes": 0
+          }
+        }
+      }
+    },
+    {
+      "query_id": "ontology_03",
+      "query": "C-type asteroid water and organics content",
+      "alias_entities_found": [
+        {
+          "id": 5843,
+          "canonical": "LTER/AND",
+          "type": "mission"
+        }
+      ],
+      "ontology_clauses": [
+        {
+          "entity_type": "asteroid",
+          "properties_filter": null,
+          "surface": "asteroid"
+        },
+        {
+          "entity_type": "asteroid",
+          "properties_filter": {
+            "taxonomy": "C"
+          },
+          "surface": "C-type"
+        }
+      ],
+      "oracle_size": 0,
+      "entity_linked_pool_size": 66,
+      "variants": {
+        "baseline": {
+          "ndcg_at_10": 0.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2022ApJ...925L..15M",
+            "2023Icar..39115300F",
+            "2014SPIE.9226E..02H",
+            "2020EPSC...14..351S",
+            "2020Natur.579..518O",
+            "2020Icar..33513404Z",
+            "2020P&SS..18704900G",
+            "2020SSRv..216..133B",
+            "2020Icar..34713817M",
+            "2020NatCo..11.3453T"
+          ],
+          "timing_ms": {
+            "lexical_ms": 38.83,
+            "body_lexical_ms": 138.39,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.04,
+            "rerank_ms": 0.0,
+            "total_ms": 177.26,
+            "wallclock_ms": 177.54
+          },
+          "search_metadata": {}
+        },
+        "alias": {
+          "ndcg_at_10": 0.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2022ApJ...925L..15M",
+            "2023Icar..39115300F",
+            "2014SPIE.9226E..02H",
+            "2020EPSC...14..351S",
+            "2020Natur.579..518O",
+            "2020Icar..33513404Z",
+            "2020P&SS..18704900G",
+            "2020SSRv..216..133B",
+            "2020Icar..34713817M",
+            "2020NatCo..11.3453T"
+          ],
+          "timing_ms": {
+            "alias_expansion_ms": 0.06,
+            "lexical_ms": 38.9,
+            "alias_lexical_ms": 125.75,
+            "body_lexical_ms": 134.57,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.03,
+            "rerank_ms": 0.0,
+            "total_ms": 299.31,
+            "wallclock_ms": 299.54
+          },
+          "search_metadata": {
+            "alias_matches": 1,
+            "alias_lanes": 1
+          }
+        },
+        "ontology": {
+          "ndcg_at_10": 0.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [],
+          "timing_ms": {
+            "ontology_parse_ms": 0.38,
+            "lexical_ms": 46.94,
+            "body_lexical_ms": 142.44,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.01,
+            "rerank_ms": 0.0,
+            "total_ms": 189.77,
+            "wallclock_ms": 189.93
+          },
+          "search_metadata": {
+            "ontology_clauses": 2,
+            "ontology_entity_ids": 0
+          }
+        },
+        "both": {
+          "ndcg_at_10": 0.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [],
+          "timing_ms": {
+            "ontology_parse_ms": 0.35,
+            "alias_expansion_ms": 0.06,
+            "lexical_ms": 42.27,
+            "alias_lexical_ms": 0.73,
+            "body_lexical_ms": 142.5,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.01,
+            "rerank_ms": 0.0,
+            "total_ms": 185.92,
+            "wallclock_ms": 186.08
+          },
+          "search_metadata": {
+            "ontology_clauses": 2,
+            "ontology_entity_ids": 0,
+            "alias_matches": 1,
+            "alias_lanes": 1
+          }
+        }
+      }
+    },
+    {
+      "query_id": "ontology_04",
+      "query": "infrared instruments on space telescopes for exoplanet detection",
+      "alias_entities_found": [
+        {
+          "id": 8945,
+          "canonical": "CA/STATSCAN/AS/ON",
+          "type": "mission"
+        },
+        {
+          "id": 8396,
+          "canonical": "UWA/ESS/SPACE",
+          "type": "mission"
+        },
+        {
+          "id": 288,
+          "canonical": "Telescopes",
+          "type": "instrument"
+        },
+        {
+          "id": 296,
+          "canonical": "TELESCOPES",
+          "type": "instrument"
+        }
+      ],
+      "ontology_clauses": [
+        {
+          "entity_type": "instrument",
+          "properties_filter": null,
+          "surface": "instruments"
+        },
+        {
+          "entity_type": "telescope",
+          "properties_filter": null,
+          "surface": "telescopes"
+        },
+        {
+          "entity_type": "exoplanet",
+          "properties_filter": null,
+          "surface": "exoplanet"
+        }
+      ],
+      "oracle_size": 30,
+      "entity_linked_pool_size": 500,
+      "variants": {
+        "baseline": {
+          "ndcg_at_10": 0.2587,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2022SPIE12184E..46S",
+            "2010ASPC..430..284E",
+            "2006ESASP1306..505O",
+            "2016SPIE.9904E..5MY",
+            "2011AdSpR..48..323E",
+            "2011SPIE.8146E..0QE",
+            "2011ASPC..450...63D",
+            "2015SPIE.9605E..0SY",
+            "2023NatAs...7.1317L",
+            "2019A&A...623A..85L"
+          ],
+          "timing_ms": {
+            "lexical_ms": 83.74,
+            "body_lexical_ms": 550.65,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.06,
+            "rerank_ms": 0.0,
+            "total_ms": 634.45,
+            "wallclock_ms": 634.74
+          },
+          "search_metadata": {}
+        },
+        "alias": {
+          "ndcg_at_10": 0.2587,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2022SPIE12184E..46S",
+            "2010ASPC..430..284E",
+            "2006ESASP1306..505O",
+            "2016SPIE.9904E..5MY",
+            "2011AdSpR..48..323E",
+            "2011SPIE.8146E..0QE",
+            "2011ASPC..450...63D",
+            "2015SPIE.9605E..0SY",
+            "2023NatAs...7.1317L",
+            "2019A&A...623A..85L"
+          ],
+          "timing_ms": {
+            "alias_expansion_ms": 0.09,
+            "lexical_ms": 27.11,
+            "alias_lexical_ms": 22078.42,
+            "body_lexical_ms": 142.91,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.08,
+            "rerank_ms": 0.0,
+            "total_ms": 22248.61,
+            "wallclock_ms": 22248.96
+          },
+          "search_metadata": {
+            "alias_matches": 4,
+            "alias_lanes": 3
+          }
+        },
+        "ontology": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2015SPIE.9605E..0SY",
+            "2019A&A...623A..85L",
+            "2019SPIE11117E..1DS",
+            "2010A&A...523A..35T",
+            "2024SPIE13092E..0YI",
+            "2021ApJ...906L..10A",
+            "2016NatCo...710436Y",
+            "2023JATIS...9c4007N",
+            "2020arXiv200302145G",
+            "2016SPIE.9904E..36F"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.04,
+            "lexical_ms": 43.13,
+            "body_lexical_ms": 154.86,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.07,
+            "rerank_ms": 0.0,
+            "total_ms": 198.1,
+            "wallclock_ms": 198.48
+          },
+          "search_metadata": {
+            "ontology_clauses": 3,
+            "ontology_entity_ids": 0
+          }
+        },
+        "both": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2015SPIE.9605E..0SY",
+            "2019A&A...623A..85L",
+            "2019SPIE11117E..1DS",
+            "2010A&A...523A..35T",
+            "2024SPIE13092E..0YI",
+            "2021ApJ...906L..10A",
+            "2016NatCo...710436Y",
+            "2023JATIS...9c4007N",
+            "2020arXiv200302145G",
+            "2016SPIE.9904E..36F"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.04,
+            "alias_expansion_ms": 0.07,
+            "lexical_ms": 27.6,
+            "alias_lexical_ms": 90035.44,
+            "body_lexical_ms": 154.62,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.06,
+            "rerank_ms": 0.0,
+            "total_ms": 90217.83,
+            "wallclock_ms": 90218.1
+          },
+          "search_metadata": {
+            "ontology_clauses": 3,
+            "ontology_entity_ids": 0,
+            "alias_matches": 4,
+            "alias_lanes": 3
+          }
+        }
+      }
+    },
+    {
+      "query_id": "ontology_07",
+      "query": "flagship NASA missions to the outer solar system",
+      "alias_entities_found": [
+        {
+          "id": 5482,
+          "canonical": "NASA",
+          "type": "mission"
+        },
+        {
+          "id": 8219,
+          "canonical": "UHI/IA/SOLAR",
+          "type": "mission"
+        }
+      ],
+      "ontology_clauses": [
+        {
+          "entity_type": "mission",
+          "properties_filter": null,
+          "surface": "missions"
+        }
+      ],
+      "oracle_size": 30,
+      "entity_linked_pool_size": 500,
+      "variants": {
+        "baseline": {
+          "ndcg_at_10": 0.5921,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2013aero.confE.245A",
+            "2025JGRE..13008507B",
+            "2025PSJ.....6...41F",
+            "2017AdSpR..59.2407M",
+            "2006epsc.conf..643J",
+            "2009EM&P..105..143O",
+            "2009rpsi.rept.....N",
+            "2018P&SS..155...12M",
+            "2024AGUFMP53C.3044K",
+            "2007AGUFM.P21B0532S"
+          ],
+          "timing_ms": {
+            "lexical_ms": 41.21,
+            "body_lexical_ms": 115.6,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.07,
+            "rerank_ms": 0.0,
+            "total_ms": 156.88,
+            "wallclock_ms": 157.24
+          },
+          "search_metadata": {}
+        },
+        "alias": {
+          "ndcg_at_10": 0.5665,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2013aero.confE.245A",
+            "2025JGRE..13008507B",
+            "2025PSJ.....6...41F",
+            "2017AdSpR..59.2407M",
+            "2006epsc.conf..643J",
+            "2009EM&P..105..143O",
+            "2009rpsi.rept.....N",
+            "2018P&SS..155...12M",
+            "2024AGUFMP53C.3044K",
+            "2012LPIBu.128...33."
+          ],
+          "timing_ms": {
+            "alias_expansion_ms": 0.06,
+            "lexical_ms": 32.55,
+            "alias_lexical_ms": 13449.21,
+            "body_lexical_ms": 62.47,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.11,
+            "rerank_ms": 0.0,
+            "total_ms": 13544.4,
+            "wallclock_ms": 13544.74
+          },
+          "search_metadata": {
+            "alias_matches": 2,
+            "alias_lanes": 2
+          }
+        },
+        "ontology": {
+          "ndcg_at_10": 0.9809,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2025JGRE..13008507B",
+            "2017AdSpR..59.2407M",
+            "2009rpsi.rept.....N",
+            "2024AGUFMP53C.3044K",
+            "2007AGUFM.P21B0532S",
+            "2007DPS....39.2805S",
+            "2007DPS....39.2803P",
+            "2020arXiv200613428P",
+            "2008AGUFM.P13D..08S",
+            "2020SSRv..216...72S"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.04,
+            "lexical_ms": 32.3,
+            "body_lexical_ms": 68.44,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.06,
+            "rerank_ms": 0.0,
+            "total_ms": 100.84,
+            "wallclock_ms": 101.11
+          },
+          "search_metadata": {
+            "ontology_clauses": 1,
+            "ontology_entity_ids": 0
+          }
+        },
+        "both": {
+          "ndcg_at_10": 0.9809,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2025JGRE..13008507B",
+            "2017AdSpR..59.2407M",
+            "2009rpsi.rept.....N",
+            "2024AGUFMP53C.3044K",
+            "2007AGUFM.P21B0532S",
+            "2007DPS....39.2805S",
+            "2007DPS....39.2803P",
+            "2020arXiv200613428P",
+            "2008AGUFM.P13D..08S",
+            "2020SSRv..216...72S"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.04,
+            "alias_expansion_ms": 0.05,
+            "lexical_ms": 30.09,
+            "alias_lexical_ms": 60026.18,
+            "body_lexical_ms": 60.97,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.06,
+            "rerank_ms": 0.0,
+            "total_ms": 60117.39,
+            "wallclock_ms": 60117.69
+          },
+          "search_metadata": {
+            "ontology_clauses": 1,
+            "ontology_entity_ids": 0,
+            "alias_matches": 2,
+            "alias_lanes": 2
+          }
+        }
+      }
+    },
+    {
+      "query_id": "mixed_01",
+      "query": "Kepler space telescope exoplanet occurrence statistics",
+      "alias_entities_found": [
+        {
+          "id": 27931,
+          "canonical": "NASA 0.95m Kepler Satellite Mission",
+          "type": "instrument"
+        },
+        {
+          "id": 8396,
+          "canonical": "UWA/ESS/SPACE",
+          "type": "mission"
+        },
+        {
+          "id": 1588868,
+          "canonical": "Kepler Space Telescope",
+          "type": "mission"
+        }
+      ],
+      "ontology_clauses": [
+        {
+          "entity_type": "telescope",
+          "properties_filter": null,
+          "surface": "telescope"
+        },
+        {
+          "entity_type": "exoplanet",
+          "properties_filter": null,
+          "surface": "exoplanet"
+        },
+        {
+          "entity_type": "telescope",
+          "properties_filter": {
+            "mission": "Kepler"
+          },
+          "surface": "Kepler"
+        }
+      ],
+      "oracle_size": 0,
+      "entity_linked_pool_size": 500,
+      "variants": {
+        "baseline": {
+          "ndcg_at_10": 0.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2018A&A...609A...4K",
+            "2023AJ....165..177S",
+            "2018AJ....155...94S",
+            "2013ApJ...764..105S",
+            "2022A&A...668A..52K",
+            "2021tsc2.confE..17T",
+            "2018adap.prop..113P",
+            "2013PhDT.......118B",
+            "2015AAS...22525736B",
+            "2020PNAS..11718264K"
+          ],
+          "timing_ms": {
+            "lexical_ms": 22.63,
+            "body_lexical_ms": 229.08,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.04,
+            "rerank_ms": 0.0,
+            "total_ms": 251.75,
+            "wallclock_ms": 252.12
+          },
+          "search_metadata": {}
+        },
+        "alias": {
+          "ndcg_at_10": 0.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [
+            "2018A&A...609A...4K",
+            "2023AJ....165..177S",
+            "2018AJ....155...94S",
+            "2013ApJ...764..105S",
+            "2022A&A...668A..52K",
+            "2021tsc2.confE..17T",
+            "2009AAS...21346409M",
+            "2013AstHe.106..528S",
+            "2018adap.prop..113P",
+            "2016JAVSO..44..168M"
+          ],
+          "timing_ms": {
+            "alias_expansion_ms": 0.06,
+            "lexical_ms": 21.18,
+            "alias_lexical_ms": 246.45,
+            "body_lexical_ms": 71.64,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.07,
+            "rerank_ms": 0.0,
+            "total_ms": 339.4,
+            "wallclock_ms": 339.68
+          },
+          "search_metadata": {
+            "alias_matches": 3,
+            "alias_lanes": 3
+          }
+        },
+        "ontology": {
+          "ndcg_at_10": 0.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [],
+          "timing_ms": {
+            "ontology_parse_ms": 0.25,
+            "lexical_ms": 19.65,
+            "body_lexical_ms": 60.08,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.01,
+            "rerank_ms": 0.0,
+            "total_ms": 79.99,
+            "wallclock_ms": 80.17
+          },
+          "search_metadata": {
+            "ontology_clauses": 3,
+            "ontology_entity_ids": 0
+          }
+        },
+        "both": {
+          "ndcg_at_10": 0.0,
+          "entity_coverage_top10": 0.0,
+          "top10": [],
+          "timing_ms": {
+            "ontology_parse_ms": 0.37,
+            "alias_expansion_ms": 0.08,
+            "lexical_ms": 19.71,
+            "alias_lexical_ms": 35.66,
+            "body_lexical_ms": 59.71,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.01,
+            "rerank_ms": 0.0,
+            "total_ms": 115.54,
+            "wallclock_ms": 115.68
+          },
+          "search_metadata": {
+            "ontology_clauses": 3,
+            "ontology_entity_ids": 0,
+            "alias_matches": 3,
+            "alias_lanes": 3
+          }
+        }
+      }
+    },
+    {
+      "query_id": "mixed_02",
+      "query": "Cassini spacecraft instruments at Saturn",
+      "alias_entities_found": [
+        {
+          "id": 27881,
+          "canonical": "NASA/ESA/ASI Cassini-Huygens Spacecraft Mission to Saturn",
+          "type": "instrument"
+        },
+        {
+          "id": 6477,
+          "canonical": "AT",
+          "type": "mission"
+        }
+      ],
+      "ontology_clauses": [
+        {
+          "entity_type": "spacecraft",
+          "properties_filter": null,
+          "surface": "spacecraft"
+        },
+        {
+          "entity_type": "instrument",
+          "properties_filter": null,
+          "surface": "instruments"
+        },
+        {
+          "entity_type": "spacecraft",
+          "properties_filter": {
+            "mission": "Cassini"
+          },
+          "surface": "Cassini"
+        }
+      ],
+      "oracle_size": 30,
+      "entity_linked_pool_size": 500,
+      "variants": {
+        "baseline": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": 0.1,
+          "top10": [
+            "2014GeoRL..41.1382J",
+            "2017AdSpR..59.1614K",
+            "2008JGRA..113.1209C",
+            "2005aero.conf..429L",
+            "2006P&SS...54..957W",
+            "2008GeoRL..35.7102C",
+            "2012JGRA..117.6220O",
+            "2022Icar..38815237J",
+            "2008JGRA..113.5210C",
+            "2010JGRA..115.8203M"
+          ],
+          "timing_ms": {
+            "lexical_ms": 13.97,
+            "body_lexical_ms": 189.39,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.08,
+            "rerank_ms": 0.0,
+            "total_ms": 203.44,
+            "wallclock_ms": 203.82
+          },
+          "search_metadata": {}
+        },
+        "alias": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": 0.1,
+          "top10": [
+            "2014GeoRL..41.1382J",
+            "2017AdSpR..59.1614K",
+            "2008JGRA..113.1209C",
+            "2005aero.conf..429L",
+            "2006P&SS...54..957W",
+            "2008GeoRL..35.7102C",
+            "2012JGRA..117.6220O",
+            "2022Icar..38815237J",
+            "2008JGRA..113.5210C",
+            "2010JGRA..115.8203M"
+          ],
+          "timing_ms": {
+            "alias_expansion_ms": 0.05,
+            "lexical_ms": 16.4,
+            "alias_lexical_ms": 2.67,
+            "body_lexical_ms": 43.67,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.07,
+            "rerank_ms": 0.0,
+            "total_ms": 62.86,
+            "wallclock_ms": 63.15
+          },
+          "search_metadata": {
+            "alias_matches": 2,
+            "alias_lanes": 2
+          }
+        },
+        "ontology": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": 0.1,
+          "top10": [
+            "2014GeoRL..41.1382J",
+            "2017AdSpR..59.1614K",
+            "2008JGRA..113.1209C",
+            "2005aero.conf..429L",
+            "2006P&SS...54..957W",
+            "2008GeoRL..35.7102C",
+            "2012JGRA..117.6220O",
+            "2022Icar..38815237J",
+            "2008JGRA..113.5210C",
+            "2010JGRA..115.8203M"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.29,
+            "lexical_ms": 23.96,
+            "body_lexical_ms": 66.04,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.08,
+            "rerank_ms": 0.0,
+            "total_ms": 90.37,
+            "wallclock_ms": 90.68
+          },
+          "search_metadata": {
+            "ontology_clauses": 3,
+            "ontology_entity_ids": 0
+          }
+        },
+        "both": {
+          "ndcg_at_10": 1.0,
+          "entity_coverage_top10": 0.1,
+          "top10": [
+            "2014GeoRL..41.1382J",
+            "2017AdSpR..59.1614K",
+            "2008JGRA..113.1209C",
+            "2005aero.conf..429L",
+            "2006P&SS...54..957W",
+            "2008GeoRL..35.7102C",
+            "2012JGRA..117.6220O",
+            "2022Icar..38815237J",
+            "2008JGRA..113.5210C",
+            "2010JGRA..115.8203M"
+          ],
+          "timing_ms": {
+            "ontology_parse_ms": 0.3,
+            "alias_expansion_ms": 0.05,
+            "lexical_ms": 21.96,
+            "alias_lexical_ms": 2.83,
+            "body_lexical_ms": 68.92,
+            "vector_ms": 0.0,
+            "openai_vector_ms": 0.0,
+            "fusion_ms": 0.07,
+            "rerank_ms": 0.0,
+            "total_ms": 94.13,
+            "wallclock_ms": 94.43
+          },
+          "search_metadata": {
+            "ontology_clauses": 3,
+            "ontology_entity_ids": 0,
+            "alias_matches": 2,
+            "alias_lanes": 2
+          }
+        }
+      }
+    }
+  ]
+}

--- a/scripts/bench_entity_query_expansion.py
+++ b/scripts/bench_entity_query_expansion.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Before/after benchmark for entity-aware query intent (xz4.1.24 + xz4.1.25).
+
+Compares four `hybrid_search` variants on 10 queries drawn from the
+calibration set:
+
+    baseline           — both flags off (current production behaviour)
+    alias              — enable_alias_expansion=True
+    ontology           — enable_ontology_parser=True
+    both               — both flags on
+
+Each variant returns its top-K bibcodes. We report:
+
+    * **nDCG@10** vs a "kitchen-sink" oracle. The oracle is constructed
+      per query as the top-30 RRF fusion of every available signal at
+      lexical_limit=200 (vector when query embeddings are available,
+      lexical, body BM25, plus the union of alias and ontology signals).
+      Both variants are evaluated on the SAME oracle, so improvements
+      reflect actual recovery of fused-signal candidates rather than
+      tautological wins.
+    * **Top-10 entity coverage** — fraction of top-10 papers linked to
+      any of the entities the alias expansion identified for the query.
+      Independent signal: measures whether the variant surfaces papers
+      that are entity-linked, regardless of oracle membership.
+
+This is a structural benchmark, NOT a topical-relevance evaluation. A
+proper topical eval requires the persona-Claude judge harness (see
+docs/prd/amendments/2026-04-18-m6-m12-collapse.md).
+
+Usage
+-----
+    SCIX_DSN=dbname=scix python scripts/bench_entity_query_expansion.py \
+        --output results/entity_query_expansion/run_$(date +%F).json
+
+Refuses to write data; the script only reads from `entities`,
+`entity_aliases`, `papers`, `paper_embeddings`, and
+`document_entities_canonical`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import statistics
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import psycopg
+
+from scix.alias_expansion import build_alias_automaton, expand_query
+from scix.db import get_connection
+from scix.ir_metrics import ndcg_at_k
+from scix.ontology_query_parser import parse_query
+from scix.search import SearchFilters, hybrid_search
+
+logger = logging.getLogger(__name__)
+
+
+# 10 benchmark queries: 4 alias-heavy, 4 ontology-heavy, 2 mixed.
+# Drawn directly from src/scix/eval/prompts/calibration_queries.yaml.
+BENCHMARK_QUERIES: list[dict[str, str]] = [
+    # alias-heavy
+    {"id": "alias_01", "query": "HST observations of cool brown dwarfs"},
+    {"id": "alias_03", "query": "JWST MIRI mid-infrared imaging of planetary nebulae"},
+    {"id": "alias_05", "query": "CMB anisotropy measurements from WMAP"},
+    {"id": "alias_06", "query": "X-ray binaries detected by Chandra"},
+    # ontology-heavy
+    {"id": "ontology_01", "query": "M-type asteroid metallic composition from near-infrared spectroscopy"},
+    {"id": "ontology_03", "query": "C-type asteroid water and organics content"},
+    {"id": "ontology_04", "query": "infrared instruments on space telescopes for exoplanet detection"},
+    {"id": "ontology_07", "query": "flagship NASA missions to the outer solar system"},
+    # mixed (both signals plausible)
+    {"id": "mixed_01", "query": "Kepler space telescope exoplanet occurrence statistics"},
+    {"id": "mixed_02", "query": "Cassini spacecraft instruments at Saturn"},
+]
+
+
+def _build_oracle(
+    conn: psycopg.Connection,
+    query: str,
+    automaton,
+    *,
+    oracle_k: int = 30,
+    lexical_limit: int = 200,
+    timeout_ms: int = 60_000,
+) -> dict[str, float] | None:
+    """Return a relevance map: bibcode -> grade in (0, 1].
+
+    The oracle is the top-K of a kitchen-sink hybrid_search run with both
+    flags ON, body BM25 ON, and a high lexical_limit. Grades decay by
+    reciprocal rank so nDCG rewards exact ordering, not just membership.
+    Returns ``None`` if the oracle build itself times out — caller should
+    skip nDCG computation for that query.
+    """
+    # Postgres SET requires a literal, not a $-param. timeout_ms is an int
+    # we control, so f-string is safe (no SQL injection surface).
+    with conn.cursor() as cur:
+        cur.execute(f"SET statement_timeout = {int(timeout_ms)}")
+    try:
+        res = hybrid_search(
+            conn,
+            query,
+            enable_alias_expansion=True,
+            enable_ontology_parser=True,
+            alias_automaton=automaton,
+            include_body=True,
+            lexical_limit=lexical_limit,
+            top_n=oracle_k,
+        )
+    except psycopg.errors.QueryCanceled:
+        logger.warning("Oracle build timed out for query=%r — skipping nDCG", query)
+        return None
+    finally:
+        # autocommit=True keeps the connection alive across QueryCanceled, so
+        # this SET always succeeds.
+        with conn.cursor() as cur:
+            cur.execute("SET statement_timeout = 0")
+
+    relevance: dict[str, float] = {}
+    for rank, paper in enumerate(res.papers, start=1):
+        bibcode = paper.get("bibcode")
+        if not bibcode:
+            continue
+        relevance[bibcode] = 1.0 / rank
+    return relevance
+
+
+def _entity_linked_bibcodes(
+    conn: psycopg.Connection,
+    entity_ids: tuple[int, ...],
+    cap: int = 500,
+) -> set[str]:
+    """Return bibcodes linked to any of the given entity_ids."""
+    if not entity_ids:
+        return set()
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT bibcode FROM document_entities_canonical "
+            "WHERE entity_id = ANY(%s) LIMIT %s",
+            (list(entity_ids), cap),
+        )
+        return {row[0] for row in cur.fetchall()}
+
+
+def _run_variant(
+    conn: psycopg.Connection,
+    query: str,
+    *,
+    automaton,
+    enable_alias: bool,
+    enable_ontology: bool,
+    top_n: int = 20,
+    timeout_ms: int = 30_000,
+) -> tuple[list[str] | None, dict[str, float], dict[str, Any]]:
+    """Run one hybrid_search variant with a hard statement timeout.
+
+    Returns (bibcodes, timing, metadata). On timeout, bibcodes is None and
+    metadata carries ``{"timeout": True, "duration_ms": <elapsed>}`` so the
+    caller can record the gap without crashing the whole benchmark.
+    """
+    # Reset the connection's statement_timeout per-call. Postgres SET requires
+    # a literal value (not a $-param); timeout_ms is an int we control.
+    with conn.cursor() as cur:
+        cur.execute(f"SET statement_timeout = {int(timeout_ms)}")
+
+    t0 = time.perf_counter()
+    try:
+        res = hybrid_search(
+            conn,
+            query,
+            enable_alias_expansion=enable_alias,
+            enable_ontology_parser=enable_ontology,
+            alias_automaton=automaton if enable_alias else None,
+            include_body=True,
+            top_n=top_n,
+        )
+    except psycopg.errors.QueryCanceled:
+        elapsed = (time.perf_counter() - t0) * 1000
+        return None, {"wallclock_ms": round(elapsed, 2)}, {"timeout": True}
+    finally:
+        # autocommit=True (set by run_benchmark) keeps the connection valid
+        # across QueryCanceled. Restore default cap.
+        with conn.cursor() as cur:
+            cur.execute("SET statement_timeout = 0")
+
+    elapsed = (time.perf_counter() - t0) * 1000
+    bibcodes = [p.get("bibcode") for p in res.papers if p.get("bibcode")]
+    timing = {**res.timing_ms, "wallclock_ms": round(elapsed, 2)}
+    return bibcodes, timing, res.metadata
+
+
+def run_benchmark(dsn: str | None, output: Path, oracle_k: int = 30) -> dict[str, Any]:
+    conn = get_connection(dsn) if dsn else get_connection()
+    # Read-only benchmark: autocommit so QueryCanceled doesn't leave the
+    # connection in an aborted-transaction state that poisons later queries.
+    conn.autocommit = True
+    try:
+        # Build a single shared automaton scoped to the entity types most
+        # relevant to the benchmark queries. None = full corpus, which is
+        # too large for an interactive run; we restrict to the small set.
+        scoped_types = (
+            "telescope",
+            "instrument",
+            "mission",
+            "spacecraft",
+            "asteroid",
+            "exoplanet",
+        )
+        logger.info("Building alias automaton for scoped entity types: %s", scoped_types)
+        automaton = build_alias_automaton(conn, entity_types=scoped_types)
+        logger.info(
+            "Automaton ready: %d entities, %d surface forms",
+            len(automaton.canonical_by_entity),
+            sum(1 for _ in automaton.automaton.keys()),
+        )
+
+        per_query: list[dict[str, Any]] = []
+        for q in BENCHMARK_QUERIES:
+            qid = q["id"]
+            query = q["query"]
+            logger.info("[%s] %s", qid, query)
+
+            # Identify entities up-front for the entity-coverage signal.
+            expansion = expand_query(conn, query, automaton=automaton)
+            parsed = parse_query(query)
+            alias_entity_ids = expansion.entity_ids
+            entity_set = _entity_linked_bibcodes(conn, alias_entity_ids)
+
+            oracle = _build_oracle(conn, query, automaton, oracle_k=oracle_k)
+            if oracle is None:
+                # Even the kitchen-sink oracle hung — record and continue.
+                per_query.append(
+                    {
+                        "query_id": qid,
+                        "query": query,
+                        "oracle_timeout": True,
+                    }
+                )
+                continue
+
+            variants: dict[str, dict[str, Any]] = {}
+            for variant_name, alias_on, onto_on in [
+                ("baseline", False, False),
+                ("alias", True, False),
+                ("ontology", False, True),
+                ("both", True, True),
+            ]:
+                bibcodes, timing, metadata = _run_variant(
+                    conn,
+                    query,
+                    automaton=automaton,
+                    enable_alias=alias_on,
+                    enable_ontology=onto_on,
+                )
+                if bibcodes is None:
+                    variants[variant_name] = {
+                        "ndcg_at_10": None,
+                        "entity_coverage_top10": None,
+                        "top10": [],
+                        "timing_ms": timing,
+                        "search_metadata": metadata,
+                        "timeout": True,
+                    }
+                    continue
+
+                ndcg = ndcg_at_k(bibcodes, oracle, k=10)
+                top10 = bibcodes[:10]
+                if entity_set:
+                    coverage = sum(1 for b in top10 if b in entity_set) / max(len(top10), 1)
+                else:
+                    coverage = float("nan")
+                variants[variant_name] = {
+                    "ndcg_at_10": round(ndcg, 4),
+                    "entity_coverage_top10": (
+                        round(coverage, 4) if coverage == coverage else None
+                    ),
+                    "top10": top10,
+                    "timing_ms": timing,
+                    "search_metadata": metadata,
+                }
+
+            per_query.append(
+                {
+                    "query_id": qid,
+                    "query": query,
+                    "alias_entities_found": [
+                        {"id": m.entity_id, "canonical": m.canonical_name, "type": m.entity_type}
+                        for m in expansion.matches
+                    ],
+                    "ontology_clauses": [
+                        {
+                            "entity_type": c.entity_type,
+                            "properties_filter": c.properties_filter,
+                            "surface": c.surface,
+                        }
+                        for c in parsed.clauses
+                    ],
+                    "oracle_size": len(oracle),
+                    "entity_linked_pool_size": len(entity_set),
+                    "variants": variants,
+                }
+            )
+
+        # Aggregate across queries — skip per-query rows where the oracle
+        # timed out (no `variants` key) or individual variants timed out.
+        summary: dict[str, dict[str, Any]] = {}
+        scored_queries = [pq for pq in per_query if "variants" in pq]
+        for variant in ("baseline", "alias", "ontology", "both"):
+            ndcgs = [
+                pq["variants"][variant]["ndcg_at_10"]
+                for pq in scored_queries
+                if pq["variants"][variant]["ndcg_at_10"] is not None
+            ]
+            covs = [
+                pq["variants"][variant]["entity_coverage_top10"]
+                for pq in scored_queries
+                if pq["variants"][variant]["entity_coverage_top10"] is not None
+            ]
+            wallclocks = [
+                pq["variants"][variant]["timing_ms"].get("wallclock_ms", 0.0)
+                for pq in scored_queries
+            ]
+            timeouts = sum(
+                1 for pq in scored_queries if pq["variants"][variant].get("timeout")
+            )
+            summary[variant] = {
+                "mean_ndcg_at_10": round(statistics.mean(ndcgs), 4) if ndcgs else None,
+                "median_ndcg_at_10": round(statistics.median(ndcgs), 4) if ndcgs else None,
+                "mean_entity_coverage_top10": (
+                    round(statistics.mean(covs), 4) if covs else None
+                ),
+                "mean_wallclock_ms": (
+                    round(statistics.mean(wallclocks), 2) if wallclocks else None
+                ),
+                "n_scored": len(ndcgs),
+                "n_timeouts": timeouts,
+                "n_queries_with_entity_pool": len(covs),
+            }
+
+        report = {
+            "schema_version": 1,
+            "generated_at": datetime.now(UTC).isoformat(),
+            "oracle": {
+                "kind": "kitchen_sink_hybrid_top_k",
+                "top_k": oracle_k,
+                "lexical_limit": 200,
+                "include_body": True,
+                "grading": "reciprocal_rank",
+                "note": (
+                    "Oracle is hybrid_search with both flags ON. Variants are "
+                    "evaluated against the same oracle so wins reflect signal "
+                    "recovery, not entity-id filter membership tautologies."
+                ),
+            },
+            "limitations": [
+                "Structural benchmark — does not measure topical relevance.",
+                "Oracle is self-referential (built with both flags ON); it "
+                "rewards variants that recover the fused-signal top-K, but "
+                "may under-credit ontology-only wins on queries where the "
+                "oracle is dominated by alias signals.",
+                "Topical evaluation requires the persona-Claude judge harness "
+                "(see docs/prd/amendments/2026-04-18-m6-m12-collapse.md).",
+            ],
+            "queries": BENCHMARK_QUERIES,
+            "summary": summary,
+            "per_query": per_query,
+        }
+
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, indent=2, default=str))
+        logger.info("Wrote %s", output)
+
+        return report
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dsn",
+        default=None,
+        help="Postgres DSN (default: SCIX_DSN env or dbname=scix)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("results/entity_query_expansion/run.json"),
+        help="Where to write the JSON report",
+    )
+    parser.add_argument(
+        "--oracle-k",
+        type=int,
+        default=30,
+        help="Top-K used to construct the oracle relevance map",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (DEBUG, INFO, WARNING)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper()),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    report = run_benchmark(args.dsn, args.output, oracle_k=args.oracle_k)
+
+    print()
+    print("=" * 70)
+    print("Entity-aware query intent benchmark — summary")
+    print("=" * 70)
+    for variant, stats in report["summary"].items():
+        ndcg = stats["mean_ndcg_at_10"]
+        cov = stats.get("mean_entity_coverage_top10")
+        lat = stats["mean_wallclock_ms"]
+        print(
+            f"  {variant:<10}  "
+            f"nDCG@10={'n/a' if ndcg is None else f'{ndcg:.4f}'}  "
+            f"coverage@10={'n/a' if cov is None else f'{cov:.4f}'}  "
+            f"latency={'n/a' if lat is None else f'{lat:>7.1f}ms'}  "
+            f"timeouts={stats['n_timeouts']}/{stats['n_scored'] + stats['n_timeouts']}"
+        )
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_semantic_communities.py
+++ b/scripts/compute_semantic_communities.py
@@ -213,13 +213,19 @@ class _SilhouetteReservoir:
         for vec, lbl in zip(vecs, labels):
             cid = int(lbl)
             bucket = self._buckets.setdefault(cid, [])
+            # `vec` is a row slice of the batch ndarray — a VIEW, not a
+            # copy. Storing the view keeps the entire batch alive via
+            # numpy's base-reference rules, which defeats the explicit
+            # `del vecs` in the predict loop and blocks GC of prior
+            # batches. np.array(..., copy=True) allocates a fresh buffer
+            # so the reservoir entry owns its own memory.
             if len(bucket) < self._per_cluster_cap:
-                bucket.append(np.asarray(vec, dtype=np.float32))
+                bucket.append(np.array(vec, dtype=np.float32, copy=True))
             else:
                 # Reservoir replacement so later batches aren't under-represented
                 j = int(self._rng.integers(0, self._per_cluster_cap * 2))
                 if j < self._per_cluster_cap:
-                    bucket[j] = np.asarray(vec, dtype=np.float32)
+                    bucket[j] = np.array(vec, dtype=np.float32, copy=True)
 
     def materialize(self) -> tuple[np.ndarray, np.ndarray]:
         vecs: list[np.ndarray] = []
@@ -532,6 +538,16 @@ def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--batch-size", type=int, default=10_000)
     parser.add_argument(
+        "--resolutions",
+        default="coarse,medium,fine",
+        help=(
+            "Comma-separated subset of resolutions to compute. Order in the "
+            "list is ignored — resolutions always run coarse -> medium -> "
+            "fine. Intended for restarting after a partial run; resolutions "
+            "already committed to paper_metrics do not need to be redone."
+        ),
+    )
+    parser.add_argument(
         "--row-limit",
         type=int,
         default=None,
@@ -612,11 +628,22 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     Path(args.results_path).parent.mkdir(parents=True, exist_ok=True)
     Path(args.run_meta_path).parent.mkdir(parents=True, exist_ok=True)
 
-    specs = [
+    requested = {r.strip() for r in args.resolutions.split(",") if r.strip()}
+    unknown = requested - set(RESOLUTION_NAMES)
+    if unknown:
+        raise SystemExit(
+            f"Unknown resolution(s): {sorted(unknown)}. "
+            f"Valid: {RESOLUTION_NAMES}"
+        )
+    all_specs = [
         ResolutionSpec("coarse", args.k_coarse),
         ResolutionSpec("medium", args.k_medium),
         ResolutionSpec("fine",   args.k_fine),
     ]
+    specs = [s for s in all_specs if s.name in requested]
+    logger.info(
+        "Running resolutions: %s", ", ".join(s.name for s in specs)
+    )
 
     results: list[ResolutionResult] = []
 

--- a/scripts/compute_semantic_communities.py
+++ b/scripts/compute_semantic_communities.py
@@ -620,12 +620,26 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     results: list[ResolutionResult] = []
 
+    # Count once up front using a short-lived connection.
     with psycopg.connect(dsn) as conn:
         conn.autocommit = False
         register_vector(conn)
         n_indus = _count_indus_rows(conn)
         logger.info("paper_embeddings(model_name='indus'): %d rows", n_indus)
-        for spec in specs:
+
+    # One connection per resolution. Under autocommit=False the outer
+    # psycopg.connect wraps everything in a SINGLE implicit transaction,
+    # so nothing commits until the connection closes — `with
+    # conn.transaction()` inside _run_resolution only creates savepoints.
+    # Running all three resolutions in one tx means (a) none of the work
+    # is durable until the final exit, and (b) cross-resolution state
+    # (cursor bookkeeping, kmeans fit history, gc-detached reservoirs)
+    # accumulates in the python process. A fresh connection per
+    # resolution commits cleanly on close and resets both ends.
+    for spec in specs:
+        with psycopg.connect(dsn) as conn:
+            conn.autocommit = False
+            register_vector(conn)
             result = _run_resolution(
                 conn,
                 spec,
@@ -635,7 +649,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 train_max_rows=args.train_max_rows,
                 row_limit=args.row_limit,
             )
-            results.append(result)
+            # Explicit commit before close so the resolution's UPDATE
+            # lands immediately in the database (visible to other
+            # connections) and backend-side state is released.
+            conn.commit()
+        results.append(result)
+        gc.collect()
 
     peak_rss_mb = _peak_rss_mb()
     finished_at = datetime.now(timezone.utc).isoformat()

--- a/scripts/generate_community_labels.py
+++ b/scripts/generate_community_labels.py
@@ -611,9 +611,16 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     taxonomic_text_by_id: dict[int, str] = {}
 
     total_upserted = 0
-    with psycopg.connect(dsn) as conn:
-        conn.autocommit = False
-        for signal, resolution in _iter_targets(args.signal):
+    # One connection per (signal, resolution) triple. Under autocommit=False
+    # a single outer psycopg.connect wraps everything in ONE implicit
+    # transaction — `with conn.transaction()` inside _label_one /
+    # _aggregate would only create savepoints, so no write would be
+    # durable until script exit, and any accidental kill mid-run would
+    # roll back all 9 triples. A fresh connection per triple commits
+    # cleanly on close and resets per-triple aggregation state.
+    for signal, resolution in _iter_targets(args.signal):
+        with psycopg.connect(dsn) as conn:
+            conn.autocommit = False
             # _label_one is atomic per resolution (one transaction).
             if signal == "taxonomic":
                 # Need the id->text mapping out of the aggregation pass —
@@ -626,7 +633,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
             n = _label_one(conn, signal, resolution)
             total_upserted += n
+            conn.commit()
 
+    # Spot-check reads from the committed communities table; use a
+    # fresh short-lived connection so we observe the just-written data
+    # and don't pin any tx state.
+    with psycopg.connect(dsn) as conn:
+        conn.autocommit = False
         spotcheck_md = _spotcheck_markdown(
             conn, taxonomic_text_by_id, args.spotcheck_n, args.seed
         )

--- a/scripts/recompute_citation_communities.py
+++ b/scripts/recompute_citation_communities.py
@@ -29,6 +29,7 @@ Outputs:
 from __future__ import annotations
 
 import argparse
+import gc
 import io
 import json
 import logging
@@ -53,7 +54,6 @@ from scix.graph_metrics import (  # noqa: E402
     compute_leiden,
     compute_nmi,
     extract_giant_component,
-    filter_isolated_nodes,
     load_graph,
 )
 
@@ -242,22 +242,31 @@ def run(
         logger.info("Loading citation graph...")
         graph, b2i, i2b = load_graph(conn)
 
-        # 2. Filter isolated nodes → subgraph of degree ≥ 1.
-        logger.info("Filtering isolated nodes...")
-        subgraph, sub_b2i, sub_i2b, isolated_bibcodes = filter_isolated_nodes(
-            graph, b2i, i2b
-        )
+        # 2. Count degree-0 nodes for run_meta (pure metric; does not mutate graph).
+        #    This avoids the memory cost of materialising an intermediate subgraph
+        #    via filter_isolated_nodes(): extract_giant_component() already lumps
+        #    degree-0 nodes into small_bibcodes, and downstream _copy_null_rows
+        #    unions isolated + small anyway — so the filter step is redundant.
+        logger.info("Counting isolated nodes...")
+        n_isolated = sum(1 for d in graph.degree() if d == 0)
+        logger.info("Found %d isolated nodes", n_isolated)
 
-        # 3. Extract giant component.
+        # 3. Extract giant component directly from full graph.
         logger.info("Extracting giant component...")
         giant, giant_b2i, giant_i2b, small_bibcodes = extract_giant_component(
-            subgraph, sub_b2i, sub_i2b
+            graph, b2i, i2b
         )
+        # Free the full-graph representation as soon as possible — peak RSS during
+        # induced_subgraph() + giant_i2b construction was what OOM'd on prod (32M
+        # nodes / 298M edges).
+        del graph, b2i, i2b
+        gc.collect()
+
         giant_n = giant.vcount()
         logger.info(
-            "Giant component: %d nodes (isolated=%d, small-component=%d)",
+            "Giant component: %d nodes (isolated=%d, non-giant total=%d)",
             giant_n,
-            len(isolated_bibcodes),
+            n_isolated,
             len(small_bibcodes),
         )
 
@@ -296,7 +305,7 @@ def run(
                 cur.execute(NULL_STAGING_SQL)
             if giant_n > 0:
                 _copy_giant_rows(conn, giant_i2b, coarse, medium, fine)
-            _copy_null_rows(conn, isolated_bibcodes | small_bibcodes)
+            _copy_null_rows(conn, small_bibcodes)
             with conn.cursor() as cur:
                 cur.execute(UPDATE_GIANT_SQL)
                 giant_updated = cur.rowcount
@@ -341,8 +350,8 @@ def run(
             "fine": resolution_fine,
         },
         "giant_component_size": giant_n,
-        "isolated_node_count": len(isolated_bibcodes),
-        "small_component_node_count": len(small_bibcodes),
+        "isolated_node_count": n_isolated,
+        "small_component_node_count": len(small_bibcodes) - n_isolated,
         "n_communities": {
             "coarse": n_coarse,
             "medium": n_medium,

--- a/scripts/recompute_citation_communities.py
+++ b/scripts/recompute_citation_communities.py
@@ -189,27 +189,31 @@ def _compute_nmi_vs_semantic(
     if not giant_bib_to_community:
         return None
 
-    bibcodes = list(giant_bib_to_community.keys())
+    # Stream the whole populated-semantic-coarse column and filter in Python.
+    # Sending ~22M bibcodes via WHERE bibcode = ANY(%s) and fetchall()ing the
+    # response (tried previously) consumes >5 GB on the prod corpus and can
+    # blow the process budget when it overlaps Leiden's working set. A named
+    # server-side cursor streams with bounded Python memory (~1 GB for the
+    # two label arrays).
+    citation_labels: list[int] = []
+    semantic_labels: list[int] = []
 
-    # Fetch semantic-coarse labels for all giant-component bibcodes.
-    with conn.cursor() as cur:
+    with conn.cursor(name="nmi_cursor") as cur:
+        cur.itersize = 500_000
         cur.execute(
             "SELECT bibcode, community_semantic_coarse "
             "FROM paper_metrics "
-            "WHERE bibcode = ANY(%s) "
-            "  AND community_semantic_coarse IS NOT NULL",
-            (bibcodes,),
+            "WHERE community_semantic_coarse IS NOT NULL"
         )
-        rows = cur.fetchall()
+        for bib, sem in cur:
+            cid = giant_bib_to_community.get(bib)
+            if cid is None:
+                continue
+            citation_labels.append(cid)
+            semantic_labels.append(int(sem))
 
-    if not rows:
+    if not citation_labels:
         return None
-
-    citation_labels: list[int] = []
-    semantic_labels: list[int] = []
-    for bib, sem in rows:
-        citation_labels.append(giant_bib_to_community[bib])
-        semantic_labels.append(int(sem))
 
     return compute_nmi(citation_labels, semantic_labels)
 
@@ -299,10 +303,10 @@ def run(
 
         # 5. Stage + UPDATE paper_metrics.
         # Must run inside a single transaction so the TEMP tables survive
-        # long enough to drive the UPDATEs. ``load_graph`` left the
-        # connection in an idle-in-transaction state (server-side cursor);
-        # commit it to start a clean transaction for the writes.
-        conn.commit()
+        # long enough to drive the UPDATEs. ``load_graph`` commits its own
+        # read transaction before returning, so by this point the connection
+        # is idle (not idle-in-tx) and ``with conn.transaction()`` starts a
+        # fresh write transaction.
         with conn.transaction():
             with conn.cursor() as cur:
                 cur.execute(STAGING_TABLE_SQL)
@@ -415,6 +419,20 @@ def main(argv: list[str] | None = None) -> int:
         logger.error(
             "Refusing to write to production DSN %s — pass --allow-prod to override",
             redact_dsn(dsn),
+        )
+        return 2
+
+    # Any --allow-prod invocation must run inside a systemd-managed unit
+    # (transient scope, service, timer, etc.) so oomd can enforce a memory
+    # ceiling without collateral-killing the gascity supervisor (see
+    # CLAUDE.md §Memory isolation). systemd sets INVOCATION_ID inside every
+    # unit and leaves it unset in plain interactive shells — making it a
+    # reliable proxy for "am I inside a cgroup oomd can manage".
+    if args.allow_prod and not os.environ.get("INVOCATION_ID"):
+        logger.error(
+            "Refusing to run --allow-prod outside a systemd scope. "
+            "Invoke via: scix-batch python %s <args...>",
+            Path(sys.argv[0]).name,
         )
         return 2
 

--- a/scripts/recompute_citation_communities.py
+++ b/scripts/recompute_citation_communities.py
@@ -239,8 +239,12 @@ def run(
     conn = psycopg.connect(dsn)
     try:
         # 1. Load full citation graph.
+        # keep_bibcode_to_id=False drops the 32M-entry bibcode→vid dict inside
+        # load_graph() once edges are resolved — it is not referenced after
+        # that point here, and retaining it pushes peak RSS into OOM territory
+        # during igraph.Graph() construction on the 32M/298M prod graph.
         logger.info("Loading citation graph...")
-        graph, b2i, i2b = load_graph(conn)
+        graph, b2i, i2b = load_graph(conn, keep_bibcode_to_id=False)
 
         # 2. Count degree-0 nodes for run_meta (pure metric; does not mutate graph).
         #    This avoids the memory cost of materialising an intermediate subgraph

--- a/src/scix/alias_expansion.py
+++ b/src/scix/alias_expansion.py
@@ -1,0 +1,493 @@
+"""Query-time alias expansion (xz4.1.24).
+
+Given a free-text user query, scan it for entity surface forms and expand
+each match to the entity's canonical name plus its other known aliases. The
+expanded term set is intended to be OR-joined into a downstream tsvector
+query and the entity ids fed to ``SearchFilters.entity_ids`` to boost
+recall in :func:`scix.search.hybrid_search`.
+
+The module is a pure library — no logging side effects, no LLM calls. It
+takes a :class:`psycopg.Connection` only to load entity rows; the actual
+matching uses :mod:`pyahocorasick` (already a hard dep via
+:mod:`scix.aho_corasick`).
+
+Disambiguation
+--------------
+
+Many aliases are homographs — e.g. ``HST`` could be ``Hubble Space
+Telescope``, ``High Speed Train`` or ``Honolulu Standard Time``. We reuse
+the long-form rule from :mod:`scix.aho_corasick`: an alias counts as a
+disambiguator if it has at least ``DISAMBIGUATOR_MIN_CHARS`` characters or
+``DISAMBIGUATOR_MIN_TOKENS`` whitespace tokens.
+
+When ``require_long_form_disambiguator=True`` (default), an ambiguous
+match (a surface form bound to more than one entity in the loaded
+automaton) fires only if a long-form alias of the same entity is also
+present in the query. User queries are usually too short to satisfy this
+co-occurrence rule, so we ALSO relax it: if the matched surface is the
+only candidate for that surface form in the loaded automaton (i.e. the
+surface is NOT a homograph in the loaded set), the match always fires.
+This is the key relaxation versus :func:`scix.aho_corasick.link_abstract`,
+which assumes abstract-length context.
+
+Caching
+-------
+
+Building an automaton from the full ``entity_aliases`` table is expensive
+(1.5M rows). The automaton is cached in module state keyed by
+``(id(conn), entity_types)``. The cache is a small insertion-ordered LRU
+because the typical caller uses very few distinct filter combinations.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Iterable
+
+import ahocorasick
+
+from scix.aho_corasick import (
+    DISAMBIGUATOR_MIN_CHARS,
+    DISAMBIGUATOR_MIN_TOKENS,
+    AhocorasickAutomaton,
+    EntityRow,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+DEFAULT_MAX_ALIASES_PER_ENTITY: int = 8
+
+# Capacity of the module-level automaton cache. Most callers use a single
+# filter combination; 8 leaves headroom without risking memory pressure on
+# the 1.5M-row full set.
+_AUTOMATON_CACHE_SIZE: int = 8
+
+_WORD_RE = re.compile(r"\w+", re.UNICODE)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AliasExpansion:
+    """One entity match found in the original query."""
+
+    entity_id: int
+    canonical_name: str
+    entity_type: str
+    matched_surface: str
+    span: tuple[int, int]
+    aliases: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ExpansionResult:
+    """Output of :func:`expand_query`."""
+
+    original_query: str
+    matches: tuple[AliasExpansion, ...]
+    expanded_terms: tuple[str, ...]
+    entity_ids: tuple[int, ...]
+
+
+# ---------------------------------------------------------------------------
+# Internal automaton payload
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _SurfacePayload:
+    """One entity's view of a single surface form.
+
+    Multiple ``_SurfacePayload`` records share the same lower-cased
+    surface form when that surface is a homograph (e.g. ``HST``).
+    """
+
+    entity_id: int
+    canonical_name: str
+    entity_type: str
+    surface: str  # original casing as stored
+    is_long_form: bool
+
+
+@dataclass(frozen=True)
+class AliasAutomaton:
+    """Pre-built automaton plus per-entity metadata.
+
+    Returned by :func:`build_alias_automaton` /
+    :func:`build_alias_automaton_from_rows` and consumed by
+    :func:`expand_query`.
+    """
+
+    automaton: AhocorasickAutomaton
+    aliases_by_entity: dict[int, tuple[str, ...]] = field(default_factory=dict)
+    canonical_by_entity: dict[int, str] = field(default_factory=dict)
+    type_by_entity: dict[int, str] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_long_form(surface: str) -> bool:
+    """Return True if ``surface`` is long enough to act as a disambiguator."""
+    if len(surface) >= DISAMBIGUATOR_MIN_CHARS:
+        return True
+    return len(_WORD_RE.findall(surface)) >= DISAMBIGUATOR_MIN_TOKENS
+
+
+def _boundary_ok(text: str, start: int, end: int) -> bool:
+    """Return True if ``text[start:end]`` sits on word boundaries."""
+    left_ok = start == 0 or not text[start - 1].isalnum()
+    right_ok = end == len(text) or not text[end].isalnum()
+    return left_ok and right_ok
+
+
+# ---------------------------------------------------------------------------
+# In-memory automaton construction
+# ---------------------------------------------------------------------------
+
+
+def build_alias_automaton_from_rows(
+    rows: Iterable[EntityRow],
+    *,
+    entity_type_by_id: dict[int, str] | None = None,
+) -> AliasAutomaton:
+    """Build an :class:`AliasAutomaton` from in-memory ``EntityRow`` records.
+
+    Parameters
+    ----------
+    rows
+        One :class:`EntityRow` per ``(entity_id, surface)`` pair. The
+        canonical name should also appear as a row (with
+        ``is_alias=False``).
+    entity_type_by_id
+        Map from ``entity_id`` to ``entity_type``. ``EntityRow`` itself
+        does not carry the type, so callers supply it explicitly. Missing
+        ids default to the empty string.
+    """
+    type_lookup = entity_type_by_id or {}
+    automaton = ahocorasick.Automaton()
+    payloads_by_key: dict[str, list[_SurfacePayload]] = {}
+    aliases_acc: dict[int, list[str]] = {}
+    canonical: dict[int, str] = {}
+    type_map: dict[int, str] = {}
+
+    for row in rows:
+        if row.ambiguity_class == "banned":
+            continue
+        surface = row.surface.strip()
+        if not surface:
+            continue
+        eid = int(row.entity_id)
+        canonical.setdefault(eid, row.canonical_name)
+        type_map.setdefault(eid, type_lookup.get(eid, ""))
+        key = surface.lower()
+        payload = _SurfacePayload(
+            entity_id=eid,
+            canonical_name=row.canonical_name,
+            entity_type=type_map[eid],
+            surface=surface,
+            is_long_form=_is_long_form(surface),
+        )
+        bucket = payloads_by_key.setdefault(key, [])
+        if any(p.entity_id == eid and p.surface == surface for p in bucket):
+            continue
+        bucket.append(payload)
+        if row.is_alias:
+            aliases_acc.setdefault(eid, []).append(surface)
+
+    for key, bucket in payloads_by_key.items():
+        automaton.add_word(key, tuple(bucket))
+    if payloads_by_key:
+        automaton.make_automaton()
+
+    aliases_by_entity = {eid: tuple(dict.fromkeys(a)) for eid, a in aliases_acc.items()}
+    return AliasAutomaton(
+        automaton=automaton,
+        aliases_by_entity=aliases_by_entity,
+        canonical_by_entity=canonical,
+        type_by_entity=type_map,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DB-backed automaton construction (cached)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_entity_rows(
+    conn,
+    entity_types: tuple[str, ...] | None,
+) -> tuple[list[EntityRow], dict[int, str]]:
+    """Pull entity surface rows from Postgres.
+
+    Returns the rows plus an ``entity_id -> entity_type`` map. Surfaces
+    include both canonical names and registered aliases.
+    """
+    rows: list[EntityRow] = []
+    type_map: dict[int, str] = {}
+
+    type_filter_sql = ""
+    type_params: list[object] = []
+    if entity_types:
+        type_filter_sql = "WHERE e.entity_type = ANY(%s)"
+        type_params = [list(entity_types)]
+
+    canonical_sql = (
+        f"SELECT e.id, e.canonical_name, e.entity_type FROM entities e {type_filter_sql}"
+    )
+    alias_sql = (
+        "SELECT ea.entity_id, ea.alias, e.canonical_name, e.entity_type "
+        "FROM entity_aliases ea "
+        f"JOIN entities e ON e.id = ea.entity_id {type_filter_sql}"
+    )
+
+    with conn.cursor() as cur:
+        cur.execute(canonical_sql, type_params)
+        for eid, canonical_name, entity_type in cur.fetchall():
+            type_map[int(eid)] = entity_type or ""
+            rows.append(
+                EntityRow(
+                    entity_id=int(eid),
+                    surface=canonical_name,
+                    canonical_name=canonical_name,
+                    ambiguity_class="unique",
+                    is_alias=False,
+                )
+            )
+        cur.execute(alias_sql, type_params)
+        for eid, alias, canonical_name, entity_type in cur.fetchall():
+            type_map.setdefault(int(eid), entity_type or "")
+            rows.append(
+                EntityRow(
+                    entity_id=int(eid),
+                    surface=alias,
+                    canonical_name=canonical_name,
+                    ambiguity_class="unique",
+                    is_alias=True,
+                )
+            )
+
+    return rows, type_map
+
+
+# Manual LRU because :func:`functools.lru_cache` cannot key on a live
+# connection object (psycopg connections are unhashable across pool
+# re-issuance) and we want explicit eviction order. Insertion-ordered
+# dict + length cap gives us LRU semantics.
+_BUNDLE_CACHE: dict[tuple[int, tuple[str, ...] | None], AliasAutomaton] = {}
+
+
+def _store_bundle(
+    key: tuple[int, tuple[str, ...] | None],
+    bundle: AliasAutomaton,
+) -> None:
+    """Insert ``bundle`` and evict oldest if over capacity."""
+    _BUNDLE_CACHE[key] = bundle
+    while len(_BUNDLE_CACHE) > _AUTOMATON_CACHE_SIZE:
+        oldest = next(iter(_BUNDLE_CACHE))
+        del _BUNDLE_CACHE[oldest]
+
+
+def clear_automaton_cache() -> None:
+    """Evict every cached automaton. Intended for tests."""
+    _BUNDLE_CACHE.clear()
+
+
+def build_alias_automaton(
+    conn,
+    *,
+    entity_types: tuple[str, ...] | None = None,
+) -> AliasAutomaton:
+    """Build (and cache) an automaton from ``entities`` + ``entity_aliases``.
+
+    Parameters
+    ----------
+    conn
+        Read-only :class:`psycopg.Connection`.
+    entity_types
+        Optional filter — restrict to these ``entity_type`` values.
+        ``None`` loads every entity (expensive on the production corpus).
+
+    Returns
+    -------
+    AliasAutomaton
+        Pre-built automaton plus per-entity canonical/alias/type metadata.
+        The same bundle is returned on subsequent calls with the same
+        ``(conn, entity_types)`` pair.
+    """
+    key = (id(conn), tuple(entity_types) if entity_types else None)
+    cached = _BUNDLE_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    rows, type_map = _fetch_entity_rows(conn, entity_types)
+    bundle = build_alias_automaton_from_rows(rows, entity_type_by_id=type_map)
+    _store_bundle(key, bundle)
+    return bundle
+
+
+# ---------------------------------------------------------------------------
+# Query expansion
+# ---------------------------------------------------------------------------
+
+
+def _scan_query(
+    query: str,
+    bundle: AliasAutomaton,
+) -> tuple[list[tuple[int, int, _SurfacePayload]], dict[int, set[str]]]:
+    """Return ``(raw_hits, long_form_present_by_entity)``.
+
+    Each homograph surface yields one entry per entity sharing it, all at
+    the same span. ``long_form_present_by_entity`` records which entity
+    ids have a long-form surface co-present somewhere in the query.
+    """
+    if not query or len(bundle.automaton) == 0:
+        return [], {}
+
+    query_lower = query.lower()
+    raw_hits: list[tuple[int, int, _SurfacePayload]] = []
+    long_form_present: dict[int, set[str]] = {}
+
+    for end_idx_inclusive, payloads in bundle.automaton.iter(query_lower):
+        first = payloads[0]
+        # The automaton key is the lower-cased surface; its length defines
+        # the match span. Original-cased surfaces may differ in length for
+        # exotic Unicode but we always use the key length here.
+        key_len = len(first.surface.lower())
+        start = end_idx_inclusive - key_len + 1
+        end = end_idx_inclusive + 1
+        if start < 0 or end > len(query_lower):
+            continue
+        if not _boundary_ok(query_lower, start, end):
+            continue
+        for payload in payloads:
+            raw_hits.append((start, end, payload))
+            if payload.is_long_form:
+                long_form_present.setdefault(payload.entity_id, set()).add(payload.surface.lower())
+
+    return raw_hits, long_form_present
+
+
+def _is_homograph_surface(bundle: AliasAutomaton, surface_lower: str) -> bool:
+    """Return True if ``surface_lower`` is bound to more than one entity."""
+    payloads = bundle.automaton.get(surface_lower, None)
+    if payloads is None:
+        return False
+    return len({p.entity_id for p in payloads}) > 1
+
+
+def expand_query(
+    conn,
+    query: str,
+    *,
+    automaton: AliasAutomaton | None = None,
+    max_aliases_per_entity: int = DEFAULT_MAX_ALIASES_PER_ENTITY,
+    require_long_form_disambiguator: bool = True,
+) -> ExpansionResult:
+    """Expand ``query`` to canonical names + aliases of matched entities.
+
+    Parameters
+    ----------
+    conn
+        Read-only :class:`psycopg.Connection`. Used only when
+        ``automaton`` is ``None``, in which case the full automaton is
+        built and cached.
+    query
+        Free-text user query.
+    automaton
+        Optional pre-built bundle from :func:`build_alias_automaton`.
+        Pass one explicitly to scope the expansion (e.g. only
+        ``mission`` and ``instrument`` entities) and to control caching.
+    max_aliases_per_entity
+        Cap on the alias list returned per match. Defends against
+        pathological entities with hundreds of aliases blowing up the
+        downstream tsvector OR-clause.
+    require_long_form_disambiguator
+        When True, ambiguous matches (a surface bound to more than one
+        entity in the loaded automaton) fire only if a long-form alias
+        of the same entity is also present in the query. Unambiguous
+        matches always fire — this is the relaxation versus
+        :func:`scix.aho_corasick.link_abstract`, which assumes
+        abstract-length context. Pass False to disable the long-form
+        gate entirely.
+    """
+    if not query:
+        return ExpansionResult(
+            original_query=query,
+            matches=(),
+            expanded_terms=(),
+            entity_ids=(),
+        )
+
+    bundle = automaton if automaton is not None else build_alias_automaton(conn)
+    raw_hits, long_form_present = _scan_query(query, bundle)
+
+    matches: list[AliasExpansion] = []
+    seen_match_keys: set[tuple[int, int, int]] = set()
+
+    for start, end, payload in raw_hits:
+        eid = payload.entity_id
+        match_key = (eid, start, end)
+        if match_key in seen_match_keys:
+            continue
+
+        surface_lower = payload.surface.lower()
+        is_homograph = _is_homograph_surface(bundle, surface_lower)
+
+        if require_long_form_disambiguator and is_homograph and not payload.is_long_form:
+            if eid not in long_form_present:
+                continue
+
+        seen_match_keys.add(match_key)
+        other_aliases = tuple(
+            a
+            for a in bundle.aliases_by_entity.get(eid, ())
+            if a != payload.surface and a != payload.canonical_name
+        )[:max_aliases_per_entity]
+        matches.append(
+            AliasExpansion(
+                entity_id=eid,
+                canonical_name=payload.canonical_name,
+                entity_type=bundle.type_by_entity.get(eid, ""),
+                matched_surface=payload.surface,
+                span=(start, end),
+                aliases=other_aliases,
+            )
+        )
+
+    expanded_seen: dict[str, None] = {}
+    entity_id_seen: dict[int, None] = {}
+    for m in matches:
+        entity_id_seen.setdefault(m.entity_id, None)
+        expanded_seen.setdefault(m.canonical_name, None)
+        for a in m.aliases:
+            expanded_seen.setdefault(a, None)
+
+    return ExpansionResult(
+        original_query=query,
+        matches=tuple(matches),
+        expanded_terms=tuple(expanded_seen),
+        entity_ids=tuple(entity_id_seen),
+    )
+
+
+__all__ = [
+    "AliasAutomaton",
+    "AliasExpansion",
+    "ExpansionResult",
+    "build_alias_automaton",
+    "build_alias_automaton_from_rows",
+    "clear_automaton_cache",
+    "expand_query",
+]

--- a/src/scix/graph_metrics.py
+++ b/src/scix/graph_metrics.py
@@ -401,13 +401,24 @@ def load_graph(
         _rss_gb(),
     )
     edge_chunk_size = 5_000_000
-    for chunk_start in range(0, edge_count, edge_chunk_size):
+    chunk_log_every = 10  # log RSS every ~50M edges
+    for chunk_idx, chunk_start in enumerate(
+        range(0, edge_count, edge_chunk_size)
+    ):
         chunk_end = min(chunk_start + edge_chunk_size, edge_count)
         chunk = np.column_stack(
             (src_arr[chunk_start:chunk_end], tgt_arr[chunk_start:chunk_end])
         )
         graph.add_edges(chunk)
         del chunk
+        if (chunk_idx + 1) % chunk_log_every == 0 or chunk_end == edge_count:
+            logger.info(
+                "  chunk %d: %d/%d edges added (RSS=%.2fGB)",
+                chunk_idx + 1,
+                chunk_end,
+                edge_count,
+                _rss_gb(),
+            )
     del src_arr, tgt_arr
     gc.collect()
     _malloc_trim()

--- a/src/scix/graph_metrics.py
+++ b/src/scix/graph_metrics.py
@@ -242,34 +242,46 @@ def _import_leidenalg() -> Any:
 
 def load_graph(
     conn: psycopg.Connection,
-) -> tuple[Any, dict[str, int], dict[int, str]]:
+    keep_bibcode_to_id: bool = True,
+) -> tuple[Any, dict[str, int], Any]:
     """Load citation graph from PostgreSQL into an igraph.Graph.
 
     Streams nodes and edges via server-side cursors to handle millions of rows
     without exhausting memory.
 
+    Args:
+        conn: PostgreSQL connection (psycopg).
+        keep_bibcode_to_id: When False, drops the bibcode→vid dict right after
+            edge resolution and returns an empty dict for the second tuple
+            element. Saves ~8 GB on the full 32M-paper graph. Set False when
+            downstream code only needs the graph + vid→bibcode reverse map
+            (e.g. the M3 Leiden recompute).
+
     Returns:
-        (graph, bibcode_to_id, id_to_bibcode) where graph is an igraph.Graph
-        and the dicts map between bibcodes and integer vertex IDs.
+        (graph, bibcode_to_id, id_to_bibcode) — graph is an igraph.Graph;
+        bibcode_to_id is dict[str, int] (or empty dict if ``keep_bibcode_to_id``
+        is False); id_to_bibcode is a ``list[str]`` where the vid is the list
+        index (smaller memory footprint than dict[int, str] by ~40 %).
     """
     igraph = _import_igraph()
 
     t0 = time.perf_counter()
 
     # --- Stream nodes ---
+    # bibcode_to_id stays a dict for O(1) edge lookup.
+    # id_to_bibcode is a list (vid → bibcode) — index-based, no hash overhead,
+    # and ~4-5 GB smaller than a 32M-entry dict on the full corpus.
     bibcode_to_id: dict[str, int] = {}
-    id_to_bibcode: dict[int, str] = {}
-    node_idx = 0
+    id_to_bibcode: list[str] = []
 
     with conn.cursor(name="node_cursor") as cur:
         cur.itersize = 500_000
         cur.execute("SELECT bibcode FROM papers")
         for (bibcode,) in cur:
-            bibcode_to_id[bibcode] = node_idx
-            id_to_bibcode[node_idx] = bibcode
-            node_idx += 1
+            bibcode_to_id[bibcode] = len(id_to_bibcode)
+            id_to_bibcode.append(bibcode)
 
-    node_count = len(bibcode_to_id)
+    node_count = len(id_to_bibcode)
     logger.info("Loaded %d nodes in %.1fs", node_count, (time.perf_counter() - t0))
 
     # --- Stream edges into numpy int32 arrays ---
@@ -313,6 +325,14 @@ def load_graph(
         skipped,
         (time.perf_counter() - t_edges),
     )
+
+    # Release the bibcode→vid dict before igraph allocates its internal
+    # representation: on the 32M-paper graph this dict is ~8 GB and pushes
+    # the process into OOM during Graph() construction. Downstream callers
+    # that only need the vid→bibcode map can opt out via keep_bibcode_to_id.
+    if not keep_bibcode_to_id:
+        bibcode_to_id = {}
+        gc.collect()
 
     # --- Build graph ---
     # igraph 1.0 accepts a (E, 2) int32 array directly. column_stack allocates

--- a/src/scix/graph_metrics.py
+++ b/src/scix/graph_metrics.py
@@ -438,6 +438,13 @@ def load_graph(
         total_ms,
     )
 
+    # Release the idle-in-transaction state left over by the server-side
+    # (named) cursors above. Downstream callers run hours of in-process work
+    # (Leiden, PageRank) before issuing another query, and holding an open
+    # read transaction that whole time blocks autovacuum, pins xmin, and
+    # risks connection-side timeouts killing the handle mid-run.
+    conn.commit()
+
     return graph, bibcode_to_id, id_to_bibcode
 
 
@@ -529,43 +536,95 @@ def extract_giant_component(
     t0 = time.perf_counter()
 
     components = graph.connected_components(mode="weak")
+    n_components = len(components)
+    logger.info(
+        "connected_components(weak): %d components (%.1fms)",
+        n_components,
+        _elapsed_ms(t0),
+    )
 
-    if len(components) <= 1:
+    if n_components <= 1:
         # Entire graph is one component (or empty) — nothing to extract
         logger.info(
-            "Graph has %d component(s); skipping giant-component extraction (%.1fms)",
-            len(components),
-            _elapsed_ms(t0),
+            "Graph has %d component(s); skipping giant-component extraction",
+            n_components,
         )
         return graph, bibcode_to_id, id_to_bibcode, set()
 
-    # Find the largest component by vertex count
-    giant_idx = max(range(len(components)), key=lambda i: len(components[i]))
-    giant_vids: list[int] = components[giant_idx]
-    giant_vid_set = set(giant_vids)
+    # Find the largest component. components.sizes() is a single O(V) pass;
+    # the obvious `max(range(n), key=lambda i: len(components[i]))` is
+    # O(C * V) because VertexClustering.__getitem__ scans the full membership
+    # vector on every call — pathological at 12M+ components.
+    t_sizes = time.perf_counter()
+    sizes = components.sizes()
+    giant_idx = max(range(len(sizes)), key=sizes.__getitem__)
+    logger.info(
+        "Located giant component: idx=%d size=%d (%.1fms)",
+        giant_idx,
+        sizes[giant_idx],
+        _elapsed_ms(t_sizes),
+    )
 
-    # Collect bibcodes in small components
-    small_bibcodes: set[str] = set()
-    for vid in range(graph.vcount()):
-        if vid not in giant_vid_set:
-            small_bibcodes.add(id_to_bibcode[vid])
+    # Derive giant_vids from the membership vector in a single O(V) pass —
+    # cheaper than `components[giant_idx]` which rescans membership.
+    t_vids = time.perf_counter()
+    membership = components.membership
+    giant_vids: list[int] = [
+        vid for vid, cid in enumerate(membership) if cid == giant_idx
+    ]
+    logger.info(
+        "Collected %d giant-component vids (%.1fms)",
+        len(giant_vids),
+        _elapsed_ms(t_vids),
+    )
+
+    # Collect bibcodes in small components — also one O(V) pass against the
+    # membership vector. Avoids re-hashing a 22M-element giant_vid_set.
+    t_small = time.perf_counter()
+    small_bibcodes: set[str] = {
+        id_to_bibcode[vid]
+        for vid, cid in enumerate(membership)
+        if cid != giant_idx
+    }
+    logger.info(
+        "Collected %d small-component bibcodes (%.1fms)",
+        len(small_bibcodes),
+        _elapsed_ms(t_small),
+    )
+    del membership
+    gc.collect()
+    _malloc_trim()
 
     # Extract giant component subgraph
+    t_sub = time.perf_counter()
     giant_graph = graph.induced_subgraph(giant_vids)
+    logger.info(
+        "induced_subgraph: %d vertices, %d edges (%.1fms) RSS=%.2fGB",
+        giant_graph.vcount(),
+        giant_graph.ecount(),
+        _elapsed_ms(t_sub),
+        _rss_gb(),
+    )
 
     # Build new contiguous ID mappings
+    t_map = time.perf_counter()
     giant_b2i: dict[str, int] = {}
     giant_i2b: dict[int, str] = {}
     for new_id, old_id in enumerate(giant_vids):
         bib = id_to_bibcode[old_id]
         giant_b2i[bib] = new_id
         giant_i2b[new_id] = bib
+    logger.info(
+        "Built giant id mappings (%.1fms) RSS=%.2fGB",
+        _elapsed_ms(t_map),
+        _rss_gb(),
+    )
 
     logger.info(
         "Giant component: %d nodes (%d small-component nodes in %d other components) (%.1fms)",
         len(giant_vids),
         len(small_bibcodes),
-        len(components) - 1,
+        n_components - 1,
         _elapsed_ms(t0),
     )
     return giant_graph, giant_b2i, giant_i2b, small_bibcodes

--- a/src/scix/graph_metrics.py
+++ b/src/scix/graph_metrics.py
@@ -6,6 +6,7 @@ evaluating partition quality against external labels or structural criteria.
 
 from __future__ import annotations
 
+import gc
 import io
 import logging
 import math
@@ -13,6 +14,7 @@ import time
 from collections import Counter
 from typing import Any
 
+import numpy as np
 import psycopg
 from psycopg.rows import dict_row
 
@@ -270,9 +272,22 @@ def load_graph(
     node_count = len(bibcode_to_id)
     logger.info("Loaded %d nodes in %.1fs", node_count, (time.perf_counter() - t0))
 
-    # --- Stream edges ---
+    # --- Stream edges into numpy int32 arrays ---
+    # A Python list of (src, tgt) tuples for 10^8+ edges costs ~70 bytes each
+    # (tuple + 2 PyLong) → ~20 GB peak at 298M edges. Writing directly into
+    # preallocated int32 arrays reduces this to ~2.4 GB and keeps the peak
+    # safely below system memory during igraph construction.
     t_edges = time.perf_counter()
-    edge_list: list[tuple[int, int]] = []
+
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM citation_edges")
+        total_rows = cur.fetchone()[0]
+    logger.info("citation_edges row count: %d (preallocating arrays)", total_rows)
+
+    # int32 holds 2.1B IDs — fine for ~32M nodes.
+    src_arr = np.empty(total_rows, dtype=np.int32)
+    tgt_arr = np.empty(total_rows, dtype=np.int32)
+    write_idx = 0
     skipped = 0
 
     with conn.cursor(name="edge_cursor") as cur:
@@ -284,9 +299,14 @@ def load_graph(
             if src_id is None or tgt_id is None:
                 skipped += 1
                 continue
-            edge_list.append((src_id, tgt_id))
+            src_arr[write_idx] = src_id
+            tgt_arr[write_idx] = tgt_id
+            write_idx += 1
 
-    edge_count = len(edge_list)
+    edge_count = write_idx
+    # Trim (cheap view) in case skips or table growth shifted the count.
+    src_arr = src_arr[:edge_count]
+    tgt_arr = tgt_arr[:edge_count]
     logger.info(
         "Loaded %d edges (skipped %d) in %.1fs",
         edge_count,
@@ -295,8 +315,15 @@ def load_graph(
     )
 
     # --- Build graph ---
+    # igraph 1.0 accepts a (E, 2) int32 array directly. column_stack allocates
+    # ~1.2 GB temporarily; free src/tgt right after to cap peak.
     t_build = time.perf_counter()
-    graph = igraph.Graph(n=node_count, edges=edge_list, directed=True)
+    edges = np.column_stack((src_arr, tgt_arr))
+    del src_arr, tgt_arr
+    gc.collect()
+    graph = igraph.Graph(n=node_count, edges=edges, directed=True)
+    del edges
+    gc.collect()
     logger.info("Built igraph in %.1fs", (time.perf_counter() - t_build))
 
     total_ms = _elapsed_ms(t0)

--- a/src/scix/graph_metrics.py
+++ b/src/scix/graph_metrics.py
@@ -388,20 +388,32 @@ def load_graph(
         logger.info("Dropped bibcode_to_id + malloc_trim (RSS=%.2fGB)", _rss_gb())
 
     # --- Build graph ---
-    # igraph 1.0 accepts a (E, 2) int32 array directly. column_stack allocates
-    # ~2.4 GB temporarily; free src/tgt right after to cap peak.
+    # Passing the full 298M-edge array to igraph.Graph(edges=...) materialises
+    # ~27 GB of transient Python state inside the python-igraph wrapper
+    # (measured at ~170 bytes/edge peak on 10M-edge test → ~50 GB for 298M).
+    # igraph.Graph(n=N) + chunked add_edges() holds the same final graph but
+    # peaks at only ~70 bytes/edge (~21 GB for 298M).
     t_build = time.perf_counter()
-    edges = np.column_stack((src_arr, tgt_arr))
+    graph = igraph.Graph(n=node_count, directed=True)
+    logger.info(
+        "Empty graph with %d vertices (RSS=%.2fGB) — adding edges in chunks...",
+        node_count,
+        _rss_gb(),
+    )
+    edge_chunk_size = 5_000_000
+    for chunk_start in range(0, edge_count, edge_chunk_size):
+        chunk_end = min(chunk_start + edge_chunk_size, edge_count)
+        chunk = np.column_stack(
+            (src_arr[chunk_start:chunk_end], tgt_arr[chunk_start:chunk_end])
+        )
+        graph.add_edges(chunk)
+        del chunk
     del src_arr, tgt_arr
     gc.collect()
     _malloc_trim()
-    logger.info("column_stack done (RSS=%.2fGB) — building igraph...", _rss_gb())
-    graph = igraph.Graph(n=node_count, edges=edges, directed=True)
-    del edges
-    gc.collect()
-    _malloc_trim()
     logger.info(
-        "Built igraph in %.1fs (RSS=%.2fGB)",
+        "Built igraph (%d edges) in %.1fs (RSS=%.2fGB)",
+        graph.ecount(),
         (time.perf_counter() - t_build),
         _rss_gb(),
     )

--- a/src/scix/graph_metrics.py
+++ b/src/scix/graph_metrics.py
@@ -6,6 +6,8 @@ evaluating partition quality against external labels or structural criteria.
 
 from __future__ import annotations
 
+import ctypes
+import ctypes.util
 import gc
 import io
 import logging
@@ -19,6 +21,47 @@ import psycopg
 from psycopg.rows import dict_row
 
 from scix.db import get_connection
+
+_LIBC: ctypes.CDLL | None = None
+
+
+def _libc() -> ctypes.CDLL | None:
+    """Return a cached libc handle for malloc_trim, or None on non-glibc."""
+    global _LIBC
+    if _LIBC is not None:
+        return _LIBC
+    try:
+        path = ctypes.util.find_library("c")
+        if path is None:
+            return None
+        _LIBC = ctypes.CDLL(path)
+        return _LIBC
+    except OSError:
+        return None
+
+
+def _malloc_trim() -> None:
+    """Ask glibc to return freed arenas to the OS (no-op on non-glibc)."""
+    lib = _libc()
+    if lib is None or not hasattr(lib, "malloc_trim"):
+        return
+    try:
+        lib.malloc_trim(0)
+    except OSError:
+        pass
+
+
+def _rss_gb() -> float:
+    """Return current process RSS in GB (Linux /proc-based, 0.0 elsewhere)."""
+    try:
+        with open("/proc/self/status", "r", encoding="ascii") as fh:
+            for line in fh:
+                if line.startswith("VmRSS:"):
+                    kb = int(line.split()[1])
+                    return round(kb / (1024 * 1024), 2)
+    except OSError:
+        pass
+    return 0.0
 
 logger = logging.getLogger(__name__)
 
@@ -282,7 +325,12 @@ def load_graph(
             id_to_bibcode.append(bibcode)
 
     node_count = len(id_to_bibcode)
-    logger.info("Loaded %d nodes in %.1fs", node_count, (time.perf_counter() - t0))
+    logger.info(
+        "Loaded %d nodes in %.1fs (RSS=%.2fGB)",
+        node_count,
+        (time.perf_counter() - t0),
+        _rss_gb(),
+    )
 
     # --- Stream edges into numpy int32 arrays ---
     # A Python list of (src, tgt) tuples for 10^8+ edges costs ~70 bytes each
@@ -320,31 +368,43 @@ def load_graph(
     src_arr = src_arr[:edge_count]
     tgt_arr = tgt_arr[:edge_count]
     logger.info(
-        "Loaded %d edges (skipped %d) in %.1fs",
+        "Loaded %d edges (skipped %d) in %.1fs (RSS=%.2fGB)",
         edge_count,
         skipped,
         (time.perf_counter() - t_edges),
+        _rss_gb(),
     )
 
     # Release the bibcode→vid dict before igraph allocates its internal
-    # representation: on the 32M-paper graph this dict is ~8 GB and pushes
+    # representation: on the 32M-paper graph this dict is ~5-8 GB and pushes
     # the process into OOM during Graph() construction. Downstream callers
     # that only need the vid→bibcode map can opt out via keep_bibcode_to_id.
+    # gc.collect() marks arenas free but glibc won't return them to OS
+    # automatically — malloc_trim forces that.
     if not keep_bibcode_to_id:
         bibcode_to_id = {}
         gc.collect()
+        _malloc_trim()
+        logger.info("Dropped bibcode_to_id + malloc_trim (RSS=%.2fGB)", _rss_gb())
 
     # --- Build graph ---
     # igraph 1.0 accepts a (E, 2) int32 array directly. column_stack allocates
-    # ~1.2 GB temporarily; free src/tgt right after to cap peak.
+    # ~2.4 GB temporarily; free src/tgt right after to cap peak.
     t_build = time.perf_counter()
     edges = np.column_stack((src_arr, tgt_arr))
     del src_arr, tgt_arr
     gc.collect()
+    _malloc_trim()
+    logger.info("column_stack done (RSS=%.2fGB) — building igraph...", _rss_gb())
     graph = igraph.Graph(n=node_count, edges=edges, directed=True)
     del edges
     gc.collect()
-    logger.info("Built igraph in %.1fs", (time.perf_counter() - t_build))
+    _malloc_trim()
+    logger.info(
+        "Built igraph in %.1fs (RSS=%.2fGB)",
+        (time.perf_counter() - t_build),
+        _rss_gb(),
+    )
 
     total_ms = _elapsed_ms(t0)
     logger.info(

--- a/src/scix/ontology_query_parser.py
+++ b/src/scix/ontology_query_parser.py
@@ -1,0 +1,341 @@
+"""Ontology-aware query parser.
+
+Lifts ontology-shaped fragments (entity types, known mission names, asteroid
+taxonomies) out of a free-text query and returns structured filters that a
+downstream hybrid search caller can apply.
+
+This module is pure mechanical orchestration code per the ZFC rule in
+``CLAUDE.md`` — a frozen vocabulary plus a hand-rolled tokenizer. No LLM
+calls, no DB access, no semantic classification. The parser is deterministic
+and side-effect free; ``parse_query`` returns a fresh ``ParsedQuery`` per
+invocation. ``residual_query`` always equals the original query: filters
+AUGMENT lexical/vector search, they do not replace text.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary (frozen at module load).
+# ---------------------------------------------------------------------------
+
+# Plural-or-singular surface form -> canonical entity_type.
+_ENTITY_TYPE_TERMS_RAW: dict[str, str] = {
+    "instruments": "instrument",
+    "instrument": "instrument",
+    "missions": "mission",
+    "mission": "mission",
+    "asteroids": "asteroid",
+    "asteroid": "asteroid",
+    "telescopes": "telescope",
+    "telescope": "telescope",
+    "spacecraft": "spacecraft",
+    "comets": "comet",
+    "comet": "comet",
+    "exoplanets": "exoplanet",
+    "exoplanet": "exoplanet",
+}
+ENTITY_TYPE_TERMS: Mapping[str, str] = MappingProxyType(_ENTITY_TYPE_TERMS_RAW)
+
+# Surface form -> canonical mission name. Stored in a case-insensitive lookup
+# table; the canonical form (preserving case) is the value we emit into the
+# JSONB containment payload.
+_KNOWN_MISSIONS_CANONICAL: tuple[str, ...] = (
+    "JWST",
+    "Hubble",
+    "HST",
+    "Chandra",
+    "Spitzer",
+    "Cassini",
+    "Voyager",
+    "Kepler",
+    "TESS",
+    "Galileo",
+    "Juno",
+    "MAVEN",
+    "Perseverance",
+)
+KNOWN_MISSIONS: frozenset[str] = frozenset(_KNOWN_MISSIONS_CANONICAL)
+_MISSION_LOOKUP: Mapping[str, str] = MappingProxyType(
+    {m.lower(): m for m in _KNOWN_MISSIONS_CANONICAL}
+)
+
+# Asteroid taxonomy letters (Tholen / Bus-DeMeo principal classes).
+ASTEROID_TAXONOMY_LETTERS: frozenset[str] = frozenset({"M", "S", "C", "V", "X", "B", "K", "L", "P"})
+
+# Token boundary: split on any run of whitespace or punctuation that is not
+# part of an asteroid-taxonomy hyphen (the asteroid pattern is matched
+# separately via regex over the raw query).
+_TOKEN_RE: re.Pattern[str] = re.compile(r"[A-Za-z][A-Za-z0-9]*")
+_ASTEROID_RE: re.Pattern[str] = re.compile(r"\b([A-Za-z])-type\b")
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OntologyClause:
+    """One lifted ontology fragment."""
+
+    entity_type: str | None
+    properties_filter: dict[str, str] | None
+    surface: str
+    span: tuple[int, int]
+
+
+@dataclass(frozen=True)
+class ParsedQuery:
+    """Result of parsing a free-text query.
+
+    ``residual_query`` is intentionally equal to ``original_query``: the
+    lifted clauses AUGMENT lexical/vector retrieval rather than replacing
+    text in the query. The caller decides how to combine clauses with the
+    underlying hybrid search.
+    """
+
+    original_query: str
+    residual_query: str
+    clauses: tuple[OntologyClause, ...]
+    entity_types: tuple[str, ...]
+    properties_filters: tuple[dict[str, str], ...]
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary accessor.
+# ---------------------------------------------------------------------------
+
+
+def default_vocabulary() -> Mapping[str, object]:
+    """Return the built-in vocabulary as a read-only mapping."""
+    return MappingProxyType(
+        {
+            "entity_type_terms": ENTITY_TYPE_TERMS,
+            "known_missions": KNOWN_MISSIONS,
+            "asteroid_taxonomy_letters": ASTEROID_TAXONOMY_LETTERS,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_vocabulary(
+    vocabulary: Mapping[str, object] | None,
+) -> tuple[Mapping[str, str], frozenset[str], Mapping[str, str], frozenset[str]]:
+    """Return (entity_terms, known_missions, mission_lookup, taxonomy_letters)."""
+    if vocabulary is None:
+        return ENTITY_TYPE_TERMS, KNOWN_MISSIONS, _MISSION_LOOKUP, ASTEROID_TAXONOMY_LETTERS
+
+    entity_terms = vocabulary.get("entity_type_terms", ENTITY_TYPE_TERMS)
+    known_missions = vocabulary.get("known_missions", KNOWN_MISSIONS)
+    taxonomy_letters = vocabulary.get("asteroid_taxonomy_letters", ASTEROID_TAXONOMY_LETTERS)
+
+    if not isinstance(entity_terms, Mapping):
+        raise TypeError("vocabulary['entity_type_terms'] must be a Mapping")
+    if not isinstance(known_missions, (frozenset, set, tuple, list)):
+        raise TypeError("vocabulary['known_missions'] must be an iterable of strings")
+    if not isinstance(taxonomy_letters, (frozenset, set, tuple, list)):
+        raise TypeError("vocabulary['asteroid_taxonomy_letters'] must be an iterable of strings")
+
+    missions_set: frozenset[str] = frozenset(str(m) for m in known_missions)
+    mission_lookup: Mapping[str, str] = MappingProxyType({m.lower(): m for m in missions_set})
+    letters_set: frozenset[str] = frozenset(str(letter) for letter in taxonomy_letters)
+    return entity_terms, missions_set, mission_lookup, letters_set
+
+
+def _scan_entity_type_clauses(
+    query: str,
+    entity_terms: Mapping[str, str],
+) -> list[OntologyClause]:
+    """Emit a clause per token whose lowercased form is an entity-type term."""
+    clauses: list[OntologyClause] = []
+    for match in _TOKEN_RE.finditer(query):
+        token = match.group(0)
+        entity_type = entity_terms.get(token.lower())
+        if entity_type is None:
+            continue
+        clauses.append(
+            OntologyClause(
+                entity_type=entity_type,
+                properties_filter=None,
+                surface=token,
+                span=(match.start(), match.end()),
+            )
+        )
+    return clauses
+
+
+def _scan_mission_clauses(
+    query: str,
+    mission_lookup: Mapping[str, str],
+    entity_type_present: bool,
+    fallback_entity_type: str | None,
+) -> list[OntologyClause]:
+    """Emit a properties-filter clause for each KNOWN_MISSIONS hit.
+
+    Mission tokens only lift to a properties filter when the query also
+    contains at least one entity-type term (the "JWST instruments" pattern).
+    The ``fallback_entity_type`` is the entity_type carried on the lifted
+    clause; when multiple entity types are present, the caller's downstream
+    UNION over entity_types still works because the JSONB filter is
+    paired with each.
+    """
+    if not entity_type_present:
+        return []
+    clauses: list[OntologyClause] = []
+    for match in _TOKEN_RE.finditer(query):
+        token = match.group(0)
+        canonical = mission_lookup.get(token.lower())
+        if canonical is None:
+            continue
+        clauses.append(
+            OntologyClause(
+                entity_type=fallback_entity_type,
+                properties_filter={"mission": canonical},
+                surface=token,
+                span=(match.start(), match.end()),
+            )
+        )
+    return clauses
+
+
+def _scan_asteroid_taxonomy_clauses(
+    query: str,
+    taxonomy_letters: frozenset[str],
+) -> list[OntologyClause]:
+    """Emit an asteroid-taxonomy clause for each ``[A-Z]-type`` hit in the allowlist."""
+    clauses: list[OntologyClause] = []
+    for match in _ASTEROID_RE.finditer(query):
+        letter = match.group(1).upper()
+        if letter not in taxonomy_letters:
+            continue
+        clauses.append(
+            OntologyClause(
+                entity_type="asteroid",
+                properties_filter={"taxonomy": letter},
+                surface=match.group(0),
+                span=(match.start(), match.end()),
+            )
+        )
+    return clauses
+
+
+def _dedupe_clauses(clauses: list[OntologyClause]) -> tuple[OntologyClause, ...]:
+    """Drop later clauses that share ``(entity_type, properties_filter)``."""
+    seen: set[tuple[str | None, tuple[tuple[str, str], ...] | None]] = set()
+    deduped: list[OntologyClause] = []
+    for clause in clauses:
+        key_props: tuple[tuple[str, str], ...] | None
+        if clause.properties_filter is None:
+            key_props = None
+        else:
+            key_props = tuple(sorted(clause.properties_filter.items()))
+        key = (clause.entity_type, key_props)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(clause)
+    return tuple(deduped)
+
+
+def _project_entity_types(clauses: tuple[OntologyClause, ...]) -> tuple[str, ...]:
+    """De-duped, insertion-ordered tuple of entity types across clauses."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for clause in clauses:
+        if clause.entity_type is None or clause.entity_type in seen:
+            continue
+        seen.add(clause.entity_type)
+        out.append(clause.entity_type)
+    return tuple(out)
+
+
+def _project_properties_filters(
+    clauses: tuple[OntologyClause, ...],
+) -> tuple[dict[str, str], ...]:
+    """De-duped, insertion-ordered tuple of properties payloads across clauses."""
+    seen: set[tuple[tuple[str, str], ...]] = set()
+    out: list[dict[str, str]] = []
+    for clause in clauses:
+        if clause.properties_filter is None:
+            continue
+        key = tuple(sorted(clause.properties_filter.items()))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(dict(clause.properties_filter))
+    return tuple(out)
+
+
+# ---------------------------------------------------------------------------
+# Public API.
+# ---------------------------------------------------------------------------
+
+
+def parse_query(
+    query: str,
+    *,
+    vocabulary: Mapping[str, object] | None = None,
+) -> ParsedQuery:
+    """Parse ``query`` and return its lifted ontology clauses.
+
+    The parser is a hand-rolled tokenizer: it scans the query for entity-type
+    terms, known-mission tokens, and asteroid-taxonomy patterns. It does not
+    rewrite or strip the query — ``residual_query`` always equals
+    ``original_query``. Filters AUGMENT lexical/vector retrieval; they do
+    not replace text.
+    """
+    if not isinstance(query, str):
+        raise TypeError(f"query must be str, got {type(query).__name__}")
+
+    entity_terms, _missions_set, mission_lookup, taxonomy_letters = _resolve_vocabulary(vocabulary)
+
+    if query == "":
+        return ParsedQuery(
+            original_query="",
+            residual_query="",
+            clauses=(),
+            entity_types=(),
+            properties_filters=(),
+        )
+
+    entity_clauses = _scan_entity_type_clauses(query, entity_terms)
+    fallback_entity_type = entity_clauses[0].entity_type if entity_clauses else None
+    mission_clauses = _scan_mission_clauses(
+        query,
+        mission_lookup,
+        entity_type_present=bool(entity_clauses),
+        fallback_entity_type=fallback_entity_type,
+    )
+    asteroid_clauses = _scan_asteroid_taxonomy_clauses(query, taxonomy_letters)
+
+    all_clauses = entity_clauses + mission_clauses + asteroid_clauses
+    deduped = _dedupe_clauses(all_clauses)
+
+    parsed = ParsedQuery(
+        original_query=query,
+        residual_query=query,
+        clauses=deduped,
+        entity_types=_project_entity_types(deduped),
+        properties_filters=_project_properties_filters(deduped),
+    )
+    logger.debug(
+        "parse_query: query=%r clauses=%d entity_types=%s properties_filters=%s",
+        query,
+        len(parsed.clauses),
+        parsed.entity_types,
+        parsed.properties_filters,
+    )
+    return parsed

--- a/src/scix/search.py
+++ b/src/scix/search.py
@@ -18,7 +18,7 @@ import psycopg
 from psycopg.rows import dict_row
 
 from scix.db import IterativeScanMode, configure_iterative_scan
-from scix.sources.ar5iv import LATEX_DERIVED_SOURCES, _ARXIV_ID_RE, _build_canonical_url
+from scix.sources.ar5iv import _ARXIV_ID_RE, LATEX_DERIVED_SOURCES, _build_canonical_url
 from scix.sources.licensing import enforce_snippet_budget
 from scix.stubs import PaperStub
 
@@ -554,6 +554,87 @@ def _model_has_embeddings(conn: psycopg.Connection, model_name: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Entity-aware query intent (alias expansion + ontology parsing)
+# ---------------------------------------------------------------------------
+
+# Cap on how many alias expansions become extra lexical RRF lanes per query —
+# bounds DB load when a query mentions many entities (e.g. "JWST MIRI NIRSpec
+# NIRCam imaging" would otherwise fan out to 4 extra SELECTs).
+_MAX_ALIAS_LEXICAL_LANES = 3
+
+# Cap on entity_ids lifted from a single properties_filter. The entities table
+# has 1.58M rows; we never want to materialise every match into the IN list.
+_MAX_PROPERTIES_FILTER_IDS = 200
+
+
+def _resolve_entity_ids_for_properties(
+    conn: psycopg.Connection,
+    properties_filters: tuple[dict[str, str], ...],
+    entity_types: tuple[str, ...] | None,
+) -> tuple[int, ...]:
+    """Look up entity_ids whose ``properties`` JSONB contains any of the supplied filters.
+
+    Each filter is applied as ``entities.properties @> %s::jsonb`` and the
+    union is returned. ``entity_types`` further restricts the lookup when
+    supplied. Capped at :data:`_MAX_PROPERTIES_FILTER_IDS` per call.
+    """
+    if not properties_filters:
+        return ()
+
+    clauses: list[str] = []
+    params: list[Any] = []
+    for payload in properties_filters:
+        clauses.append("properties @> %s::jsonb")
+        params.append(json.dumps(payload))
+
+    type_clause = ""
+    if entity_types:
+        type_clause = " AND entity_type = ANY(%s)"
+        params.append(list(entity_types))
+
+    sql = f"SELECT id FROM entities WHERE ({' OR '.join(clauses)}){type_clause} LIMIT %s"
+    params.append(_MAX_PROPERTIES_FILTER_IDS)
+
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        return tuple(int(row[0]) for row in cur.fetchall())
+
+
+def _merge_filters(
+    base: SearchFilters | None,
+    *,
+    extra_entity_types: tuple[str, ...] = (),
+    extra_entity_ids: tuple[int, ...] = (),
+) -> SearchFilters:
+    """Return a new :class:`SearchFilters` with extra entity scopes UNION'd in.
+
+    Empty extras leave the field unchanged. Existing filter scalar fields
+    (year, doctype, etc.) carry through verbatim.
+    """
+    base = base or SearchFilters()
+
+    if extra_entity_types:
+        merged_types = tuple(dict.fromkeys((*(base.entity_types or ()), *extra_entity_types)))
+    else:
+        merged_types = base.entity_types
+
+    if extra_entity_ids:
+        merged_ids = tuple(dict.fromkeys((*(base.entity_ids or ()), *extra_entity_ids)))
+    else:
+        merged_ids = base.entity_ids
+
+    return SearchFilters(
+        year_min=base.year_min,
+        year_max=base.year_max,
+        arxiv_class=base.arxiv_class,
+        doctype=base.doctype,
+        first_author=base.first_author,
+        entity_types=merged_types,
+        entity_ids=merged_ids,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Hybrid search (vector + lexical + RRF + optional cross-encoder rerank)
 # ---------------------------------------------------------------------------
 
@@ -573,6 +654,9 @@ def hybrid_search(
     ef_search: int = 100,
     reranker: Any | None = None,
     include_body: bool = True,
+    enable_alias_expansion: bool = False,
+    enable_ontology_parser: bool = False,
+    alias_automaton: Any | None = None,
 ) -> SearchResult:
     """Hybrid search combining vector and lexical via RRF, with optional reranking.
 
@@ -591,14 +675,89 @@ def hybrid_search(
         include_body: When True (default), runs body BM25 as a 4th RRF signal
             against the GIN expression index on papers.body. Set to False to
             skip when body coverage is irrelevant or for benchmarking.
+        enable_alias_expansion: When True, runs :func:`scix.alias_expansion.expand_query`
+            on ``query_text`` and adds one extra lexical RRF lane per matched
+            entity (canonical name as the lane query), capped at
+            :data:`_MAX_ALIAS_LEXICAL_LANES`. Default False.
+        enable_ontology_parser: When True, runs :func:`scix.ontology_query_parser.parse_query`
+            on ``query_text`` and lifts ``entity_types`` plus
+            ``properties_filters`` (resolved to entity_ids) into ``filters``.
+            Default False.
+        alias_automaton: Optional pre-built :class:`AliasAutomaton`. When None
+            and ``enable_alias_expansion`` is True, a global cached automaton
+            is built lazily from the ``entities``/``entity_aliases`` tables.
     """
     timing: dict[str, float] = {}
+    metadata: dict[str, Any] = {}
+
+    # Ontology parsing — lift to filters BEFORE lexical/vector calls so all
+    # downstream stages see the augmented scope.
+    if enable_ontology_parser:
+        from scix.ontology_query_parser import parse_query
+
+        t_parse = time.perf_counter()
+        parsed = parse_query(query_text)
+        property_ids: tuple[int, ...] = ()
+        if parsed.properties_filters:
+            property_ids = _resolve_entity_ids_for_properties(
+                conn,
+                parsed.properties_filters,
+                parsed.entity_types or None,
+            )
+        if parsed.entity_types or property_ids:
+            filters = _merge_filters(
+                filters,
+                extra_entity_types=parsed.entity_types,
+                extra_entity_ids=property_ids,
+            )
+        timing["ontology_parse_ms"] = _elapsed_ms(t_parse)
+        metadata["ontology_clauses"] = len(parsed.clauses)
+        metadata["ontology_entity_ids"] = len(property_ids)
+
+    # Alias expansion — collect extra lexical lanes (no filter mutation, since
+    # an entity-id filter would over-restrict recall vs. simple OR'd lexical
+    # rerank). Each extra lane is a lexical_search on the matched entity's
+    # canonical name; RRF fusion handles deduplication.
+    alias_lane_queries: list[str] = []
+    if enable_alias_expansion:
+        from scix.alias_expansion import expand_query
+
+        t_alias = time.perf_counter()
+        expansion = expand_query(conn, query_text, automaton=alias_automaton)
+        seen: set[str] = set()
+        for match in expansion.matches:
+            canonical = match.canonical_name.strip()
+            key = canonical.lower()
+            if not canonical or key in seen:
+                continue
+            seen.add(key)
+            alias_lane_queries.append(canonical)
+            if len(alias_lane_queries) >= _MAX_ALIAS_LEXICAL_LANES:
+                break
+        timing["alias_expansion_ms"] = _elapsed_ms(t_alias)
+        metadata["alias_matches"] = len(expansion.matches)
+        metadata["alias_lanes"] = len(alias_lane_queries)
 
     # Lexical search (title + abstract tsvector)
     lex_result = lexical_search(conn, query_text, filters=filters, limit=lexical_limit)
     timing["lexical_ms"] = lex_result.timing_ms["lexical_ms"]
 
     results_lists: list[list[dict[str, Any]]] = [lex_result.papers]
+
+    # Extra alias lexical lanes — one per matched entity canonical name.
+    if alias_lane_queries:
+        t_alias_lex = time.perf_counter()
+        for lane_query in alias_lane_queries:
+            try:
+                lane = lexical_search(conn, lane_query, filters=filters, limit=lexical_limit)
+            except Exception:
+                logger.warning(
+                    "Alias lexical lane failed for %r; continuing", lane_query, exc_info=True
+                )
+                continue
+            if lane.papers:
+                results_lists.append(lane.papers)
+        timing["alias_lexical_ms"] = _elapsed_ms(t_alias_lex)
 
     # Body BM25 (full-text via GIN expression index on papers.body)
     timing["body_lexical_ms"] = 0.0
@@ -690,6 +849,7 @@ def hybrid_search(
         papers=fused,
         total=len(fused),
         timing_ms=timing,
+        metadata=metadata,
     )
 
 

--- a/tests/test_alias_expansion.py
+++ b/tests/test_alias_expansion.py
@@ -1,0 +1,369 @@
+"""Tests for query-time alias expansion (xz4.1.24).
+
+Two layers:
+
+* Pure-library tests of :mod:`scix.alias_expansion` — no DB required.
+  They build small in-memory automatons and exercise homograph handling,
+  case-insensitive matching, dedup, alias caps, and empty-query
+  handling.
+* DB integration tests (marked ``@pytest.mark.integration``) that seed
+  two entities into ``SCIX_TEST_DSN`` inside a savepoint, build the
+  automaton from the DB, and assert end-to-end behavior.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+import psycopg
+import pytest
+
+from scix.aho_corasick import EntityRow
+from scix.alias_expansion import (
+    AliasAutomaton,
+    AliasExpansion,
+    ExpansionResult,
+    build_alias_automaton,
+    build_alias_automaton_from_rows,
+    clear_automaton_cache,
+    expand_query,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures (in-memory)
+# ---------------------------------------------------------------------------
+
+
+def _hubble_rows() -> list[EntityRow]:
+    return [
+        EntityRow(
+            entity_id=101,
+            surface="Hubble Space Telescope",
+            canonical_name="Hubble Space Telescope",
+            ambiguity_class="unique",
+            is_alias=False,
+        ),
+        EntityRow(
+            entity_id=101,
+            surface="HST",
+            canonical_name="Hubble Space Telescope",
+            ambiguity_class="unique",
+            is_alias=True,
+        ),
+        EntityRow(
+            entity_id=101,
+            surface="Hubble",
+            canonical_name="Hubble Space Telescope",
+            ambiguity_class="unique",
+            is_alias=True,
+        ),
+    ]
+
+
+def _psyche_homograph_rows() -> list[EntityRow]:
+    """Two entities both carrying the alias 'Psyche'."""
+    asteroid = [
+        EntityRow(
+            entity_id=201,
+            surface="16 Psyche",
+            canonical_name="16 Psyche",
+            ambiguity_class="unique",
+            is_alias=False,
+        ),
+        EntityRow(
+            entity_id=201,
+            surface="Psyche",
+            canonical_name="16 Psyche",
+            ambiguity_class="unique",
+            is_alias=True,
+        ),
+        EntityRow(
+            entity_id=201,
+            surface="Psyche asteroid",
+            canonical_name="16 Psyche",
+            ambiguity_class="unique",
+            is_alias=True,
+        ),
+    ]
+    spacecraft = [
+        EntityRow(
+            entity_id=202,
+            surface="Psyche Mission",
+            canonical_name="Psyche Mission",
+            ambiguity_class="unique",
+            is_alias=False,
+        ),
+        EntityRow(
+            entity_id=202,
+            surface="Psyche",
+            canonical_name="Psyche Mission",
+            ambiguity_class="unique",
+            is_alias=True,
+        ),
+    ]
+    return asteroid + spacecraft
+
+
+def _hubble_automaton() -> AliasAutomaton:
+    return build_alias_automaton_from_rows(
+        _hubble_rows(),
+        entity_type_by_id={101: "telescope"},
+    )
+
+
+def _psyche_automaton() -> AliasAutomaton:
+    return build_alias_automaton_from_rows(
+        _psyche_homograph_rows(),
+        entity_type_by_id={201: "asteroid", 202: "spacecraft"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — basic expansion
+# ---------------------------------------------------------------------------
+
+
+class TestBasicExpansion:
+    def test_expands_acronym_to_canonical_and_aliases(self) -> None:
+        bundle = _hubble_automaton()
+        result = expand_query(None, "HST observations of cool brown dwarfs", automaton=bundle)
+        assert isinstance(result, ExpansionResult)
+        assert result.entity_ids == (101,)
+        assert "Hubble Space Telescope" in result.expanded_terms
+        assert "Hubble" in result.expanded_terms
+        # The matched surface itself is not duplicated into expanded_terms
+        # via the alias path — it appears in matched_surface and may also
+        # not be in `aliases` because we strip the matched_surface out.
+        assert all(isinstance(t, str) for t in result.expanded_terms)
+
+    def test_match_records_span_and_surface(self) -> None:
+        bundle = _hubble_automaton()
+        query = "HST observations of cool brown dwarfs"
+        result = expand_query(None, query, automaton=bundle)
+        assert len(result.matches) == 1
+        m = result.matches[0]
+        assert isinstance(m, AliasExpansion)
+        assert m.entity_id == 101
+        assert m.canonical_name == "Hubble Space Telescope"
+        assert m.entity_type == "telescope"
+        assert m.matched_surface == "HST"
+        assert query[m.span[0] : m.span[1]] == "HST"
+
+    def test_aliases_exclude_matched_surface_and_canonical(self) -> None:
+        bundle = _hubble_automaton()
+        result = expand_query(None, "HST imaging", automaton=bundle)
+        m = result.matches[0]
+        assert "HST" not in m.aliases
+        assert "Hubble Space Telescope" not in m.aliases
+        assert "Hubble" in m.aliases
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — disambiguation
+# ---------------------------------------------------------------------------
+
+
+class TestHomographDisambiguation:
+    def test_short_homograph_alone_is_dropped(self) -> None:
+        """'Psyche' alone is a homograph — should drop both entities."""
+        bundle = _psyche_automaton()
+        result = expand_query(None, "Psyche surface mineralogy", automaton=bundle)
+        assert (
+            result.entity_ids == ()
+        ), f"Expected no matches for ambiguous bare 'Psyche', got {result.entity_ids}"
+
+    def test_long_form_co_present_resolves_homograph(self) -> None:
+        """When 'Psyche asteroid' (long-form alias of 201) is present, only
+        the asteroid entity fires for the bare 'Psyche' surface."""
+        bundle = _psyche_automaton()
+        query = "Psyche asteroid composition Psyche imaging"
+        result = expand_query(None, query, automaton=bundle)
+        assert 201 in result.entity_ids
+        assert 202 not in result.entity_ids
+
+    def test_unambiguous_short_surface_fires(self) -> None:
+        """HST is short but unambiguous in the loaded automaton — must fire
+        despite the long-form gate (the relaxation rule)."""
+        bundle = _hubble_automaton()
+        result = expand_query(None, "HST imaging", automaton=bundle)
+        assert result.entity_ids == (101,)
+
+    def test_disambiguator_off_fires_every_match(self) -> None:
+        bundle = _psyche_automaton()
+        result = expand_query(
+            None,
+            "Psyche surface mineralogy",
+            automaton=bundle,
+            require_long_form_disambiguator=False,
+        )
+        assert set(result.entity_ids) == {201, 202}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — case insensitivity, dedup, caps, empty
+# ---------------------------------------------------------------------------
+
+
+class TestCaseAndDedup:
+    def test_lowercase_query_matches_mixed_case_surface(self) -> None:
+        bundle = _hubble_automaton()
+        result = expand_query(None, "hubble space telescope deep field", automaton=bundle)
+        assert result.entity_ids == (101,)
+
+    def test_uppercase_query_matches_mixed_case_surface(self) -> None:
+        bundle = _hubble_automaton()
+        result = expand_query(None, "HUBBLE deep field", automaton=bundle)
+        assert result.entity_ids == (101,)
+
+    def test_dedup_when_canonical_and_alias_both_hit(self) -> None:
+        """'HST' (alias) and 'Hubble Space Telescope' (canonical) both
+        appear in the query — entity_ids and expanded_terms must dedup."""
+        bundle = _hubble_automaton()
+        query = "HST and the Hubble Space Telescope archive"
+        result = expand_query(None, query, automaton=bundle)
+        assert result.entity_ids == (101,)
+        # canonical name appears once in expanded_terms
+        assert result.expanded_terms.count("Hubble Space Telescope") == 1
+        # both spans recorded as separate matches
+        spans = [m.span for m in result.matches]
+        assert len(spans) == len(set(spans))
+
+
+class TestAliasCap:
+    def test_max_aliases_per_entity_respected(self) -> None:
+        rows = [
+            EntityRow(
+                entity_id=900,
+                surface="Big Entity",
+                canonical_name="Big Entity",
+                ambiguity_class="unique",
+                is_alias=False,
+            )
+        ]
+        for i in range(20):
+            rows.append(
+                EntityRow(
+                    entity_id=900,
+                    surface=f"alias_{i:02d}",
+                    canonical_name="Big Entity",
+                    ambiguity_class="unique",
+                    is_alias=True,
+                )
+            )
+        bundle = build_alias_automaton_from_rows(rows, entity_type_by_id={900: "thing"})
+        result = expand_query(
+            None,
+            "alias_03 study",
+            automaton=bundle,
+            max_aliases_per_entity=5,
+        )
+        assert len(result.matches) == 1
+        assert len(result.matches[0].aliases) == 5
+
+
+class TestEmptyAndBoundaries:
+    def test_empty_query_returns_empty_result(self) -> None:
+        bundle = _hubble_automaton()
+        result = expand_query(None, "", automaton=bundle)
+        assert result == ExpansionResult(
+            original_query="",
+            matches=(),
+            expanded_terms=(),
+            entity_ids=(),
+        )
+
+    def test_empty_query_preserves_original(self) -> None:
+        bundle = _hubble_automaton()
+        result = expand_query(None, "", automaton=bundle)
+        assert result.original_query == ""
+
+    def test_no_match_returns_empty_with_query(self) -> None:
+        bundle = _hubble_automaton()
+        result = expand_query(None, "completely unrelated text", automaton=bundle)
+        assert result.original_query == "completely unrelated text"
+        assert result.matches == ()
+        assert result.entity_ids == ()
+        assert result.expanded_terms == ()
+
+    def test_word_boundary_avoids_substring_hit(self) -> None:
+        """'HST' must not match inside 'GHOST'."""
+        bundle = _hubble_automaton()
+        result = expand_query(None, "GHOST imaging survey", automaton=bundle)
+        assert result.entity_ids == ()
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — require SCIX_TEST_DSN
+# ---------------------------------------------------------------------------
+
+
+def _test_dsn_or_skip() -> str:
+    dsn = os.environ.get("SCIX_TEST_DSN")
+    if not dsn:
+        pytest.skip("SCIX_TEST_DSN not set — skipping DB integration test")
+    return dsn
+
+
+@pytest.fixture()
+def db_conn() -> Iterator[psycopg.Connection]:
+    """Yield a connection to ``SCIX_TEST_DSN`` and roll back at teardown.
+
+    Skips the test if ``SCIX_TEST_DSN`` is unset or unreachable.
+    """
+    dsn = _test_dsn_or_skip()
+    try:
+        conn = psycopg.connect(dsn)
+    except psycopg.OperationalError as exc:
+        pytest.skip(f"SCIX_TEST_DSN unreachable: {exc}")
+    conn.autocommit = False
+    try:
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+        clear_automaton_cache()
+
+
+@pytest.mark.integration
+class TestExpandQueryIntegration:
+    def test_jwst_miri_round_trip(self, db_conn: psycopg.Connection) -> None:
+        """Insert two entities + aliases, build automaton from DB, expand."""
+        with db_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO entities (canonical_name, entity_type, source)
+                VALUES (%s, %s, %s) RETURNING id
+                """,
+                ("James Webb Space Telescope", "mission", "test_alias_expansion"),
+            )
+            jwst_id = cur.fetchone()[0]
+            cur.execute(
+                """
+                INSERT INTO entities (canonical_name, entity_type, source)
+                VALUES (%s, %s, %s) RETURNING id
+                """,
+                ("Mid-Infrared Instrument", "instrument", "test_alias_expansion"),
+            )
+            miri_id = cur.fetchone()[0]
+            cur.executemany(
+                """
+                INSERT INTO entity_aliases (entity_id, alias, alias_source)
+                VALUES (%s, %s, %s)
+                """,
+                [
+                    (jwst_id, "JWST", "test_alias_expansion"),
+                    (jwst_id, "Webb", "test_alias_expansion"),
+                    (miri_id, "MIRI", "test_alias_expansion"),
+                ],
+            )
+
+        # Force a rebuild — clear cache because the data changed mid-txn.
+        clear_automaton_cache()
+        bundle = build_alias_automaton(db_conn)
+        result = expand_query(db_conn, "JWST MIRI imaging", automaton=bundle)
+
+        assert jwst_id in result.entity_ids
+        assert miri_id in result.entity_ids
+        assert "James Webb Space Telescope" in result.expanded_terms
+        assert "Mid-Infrared Instrument" in result.expanded_terms

--- a/tests/test_ontology_query_parser.py
+++ b/tests/test_ontology_query_parser.py
@@ -1,0 +1,230 @@
+"""Tests for the ontology-aware query parser (xz4.1.25)."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from scix.ontology_query_parser import (
+    ASTEROID_TAXONOMY_LETTERS,
+    ENTITY_TYPE_TERMS,
+    KNOWN_MISSIONS,
+    OntologyClause,
+    default_vocabulary,
+    parse_query,
+)
+
+# ---------------------------------------------------------------------------
+# Behaviour against the bead's worked examples.
+# ---------------------------------------------------------------------------
+
+
+class TestParseQueryWorkedExamples:
+    def test_jwst_instruments_lifts_entity_type_and_mission(self) -> None:
+        parsed = parse_query("JWST instruments")
+
+        assert "instrument" in parsed.entity_types
+        assert {"mission": "JWST"} in parsed.properties_filters
+        assert parsed.original_query == "JWST instruments"
+        assert parsed.residual_query == "JWST instruments"
+
+    def test_flagship_nasa_missions_yields_mission_only(self) -> None:
+        parsed = parse_query("flagship NASA missions to the outer solar system")
+
+        assert "mission" in parsed.entity_types
+        # NASA is not a mission; KNOWN_MISSIONS holds only specific missions.
+        assert parsed.properties_filters == ()
+
+    def test_m_type_asteroid_lifts_taxonomy_letter(self) -> None:
+        parsed = parse_query("M-type asteroid metallic composition from near-infrared spectroscopy")
+
+        assert "asteroid" in parsed.entity_types
+        assert {"taxonomy": "M"} in parsed.properties_filters
+
+    def test_multiple_entity_types_in_one_query(self) -> None:
+        parsed = parse_query("infrared instruments on space telescopes for exoplanet detection")
+
+        assert "instrument" in parsed.entity_types
+        assert "telescope" in parsed.entity_types
+        assert "exoplanet" in parsed.entity_types
+
+    def test_no_ontology_terms_returns_empty(self) -> None:
+        parsed = parse_query("dark matter")
+
+        assert parsed.clauses == ()
+        assert parsed.entity_types == ()
+        assert parsed.properties_filters == ()
+        assert parsed.residual_query == "dark matter"
+
+    def test_empty_query(self) -> None:
+        parsed = parse_query("")
+
+        assert parsed.original_query == ""
+        assert parsed.residual_query == ""
+        assert parsed.clauses == ()
+        assert parsed.entity_types == ()
+        assert parsed.properties_filters == ()
+
+
+# ---------------------------------------------------------------------------
+# residual_query parity (filters AUGMENT, never strip).
+# ---------------------------------------------------------------------------
+
+
+class TestResidualQueryParity:
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "",
+            "dark matter",
+            "JWST instruments",
+            "M-type asteroid metallic composition",
+            "flagship NASA missions to the outer solar system",
+            "infrared instruments on space telescopes for exoplanet detection",
+            "Cassini mission to Saturn",
+            "Voyager spacecraft outer planets",
+        ],
+    )
+    def test_residual_equals_original(self, query: str) -> None:
+        parsed = parse_query(query)
+        assert parsed.residual_query == parsed.original_query == query
+
+
+# ---------------------------------------------------------------------------
+# Clause-level structure.
+# ---------------------------------------------------------------------------
+
+
+class TestClauseStructure:
+    def test_entity_type_clause_has_token_span(self) -> None:
+        parsed = parse_query("JWST instruments")
+        entity_clauses = [c for c in parsed.clauses if c.properties_filter is None]
+        assert len(entity_clauses) == 1
+        clause = entity_clauses[0]
+        assert clause.entity_type == "instrument"
+        assert clause.surface == "instruments"
+        start, end = clause.span
+        assert "JWST instruments"[start:end] == "instruments"
+
+    def test_mission_clause_has_canonical_form_and_span(self) -> None:
+        parsed = parse_query("jwst instruments")
+        mission_clauses = [c for c in parsed.clauses if c.properties_filter is not None]
+        assert len(mission_clauses) == 1
+        clause = mission_clauses[0]
+        assert clause.properties_filter == {"mission": "JWST"}
+        assert clause.surface == "jwst"
+        start, end = clause.span
+        assert "jwst instruments"[start:end] == "jwst"
+
+    def test_asteroid_taxonomy_clause(self) -> None:
+        parsed = parse_query("S-type asteroid silicate")
+        tax_clauses = [c for c in parsed.clauses if c.properties_filter == {"taxonomy": "S"}]
+        assert len(tax_clauses) == 1
+        clause = tax_clauses[0]
+        assert clause.entity_type == "asteroid"
+        start, end = clause.span
+        assert "S-type asteroid silicate"[start:end] == "S-type"
+
+    def test_mission_without_entity_type_is_not_lifted(self) -> None:
+        # No entity-type token in this query -> mission clause not emitted.
+        parsed = parse_query("JWST captured a beautiful image")
+        assert parsed.entity_types == ()
+        assert parsed.properties_filters == ()
+        assert parsed.clauses == ()
+
+    def test_unknown_taxonomy_letter_ignored(self) -> None:
+        # 'Z' is not in ASTEROID_TAXONOMY_LETTERS allowlist.
+        parsed = parse_query("Z-type asteroid")
+        assert {"taxonomy": "Z"} not in parsed.properties_filters
+
+    def test_dedupe_repeated_entity_type(self) -> None:
+        parsed = parse_query("instrument and instruments are instrument synonyms")
+        instrument_clauses = [
+            c
+            for c in parsed.clauses
+            if c.entity_type == "instrument" and c.properties_filter is None
+        ]
+        assert len(instrument_clauses) == 1
+
+
+# ---------------------------------------------------------------------------
+# Immutability and frozen dataclass semantics.
+# ---------------------------------------------------------------------------
+
+
+class TestImmutability:
+    def test_parsed_query_is_frozen(self) -> None:
+        parsed = parse_query("JWST instruments")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            parsed.original_query = "mutated"  # type: ignore[misc]
+
+    def test_ontology_clause_is_frozen(self) -> None:
+        clause = OntologyClause(
+            entity_type="instrument",
+            properties_filter=None,
+            surface="instruments",
+            span=(0, 11),
+        )
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            clause.entity_type = "mission"  # type: ignore[misc]
+
+    def test_default_vocabulary_returns_constants(self) -> None:
+        vocab = default_vocabulary()
+        assert vocab["entity_type_terms"] is ENTITY_TYPE_TERMS
+        assert vocab["known_missions"] is KNOWN_MISSIONS
+        assert vocab["asteroid_taxonomy_letters"] is ASTEROID_TAXONOMY_LETTERS
+
+
+# ---------------------------------------------------------------------------
+# Determinism: same input -> equal output.
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    @given(
+        st.text(
+            alphabet=st.characters(
+                blacklist_categories=("Cs",),
+                whitelist_categories=("Lu", "Ll", "Nd", "Zs", "Po"),
+            ),
+            min_size=0,
+            max_size=120,
+        )
+    )
+    def test_parse_query_is_deterministic(self, query: str) -> None:
+        first = parse_query(query)
+        second = parse_query(query)
+        assert first == second
+
+    def test_parsed_query_equality_uses_value_semantics(self) -> None:
+        a = parse_query("JWST instruments")
+        b = parse_query("JWST instruments")
+        assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Type-safety and input validation.
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    def test_non_string_query_raises_type_error(self) -> None:
+        with pytest.raises(TypeError):
+            parse_query(123)  # type: ignore[arg-type]
+
+    def test_custom_vocabulary_overrides_default(self) -> None:
+        custom = {
+            "entity_type_terms": {"galaxies": "galaxy", "galaxy": "galaxy"},
+            "known_missions": frozenset({"SDSS"}),
+            "asteroid_taxonomy_letters": frozenset({"M"}),
+        }
+        parsed = parse_query("SDSS galaxies in the local universe", vocabulary=custom)
+        assert "galaxy" in parsed.entity_types
+        assert {"mission": "SDSS"} in parsed.properties_filters
+
+    def test_custom_vocabulary_wrong_type_raises(self) -> None:
+        with pytest.raises(TypeError):
+            parse_query("anything", vocabulary={"entity_type_terms": ["bad"]})

--- a/tests/test_search_query_intent.py
+++ b/tests/test_search_query_intent.py
@@ -1,0 +1,468 @@
+"""Tests for hybrid_search alias-expansion + ontology-parser flags.
+
+The unit tests mock all DB-touching helpers (lexical_search, vector_search,
+_resolve_entity_ids_for_properties) so they run without a database. The
+integration test gates on SCIX_TEST_DSN — see CLAUDE.md "Database Safety".
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scix.aho_corasick import EntityRow
+from scix.alias_expansion import (
+    build_alias_automaton_from_rows,
+    clear_automaton_cache,
+)
+from scix.search import (
+    SearchFilters,
+    SearchResult,
+    _merge_filters,
+    hybrid_search,
+)
+
+# ---------------------------------------------------------------------------
+# _merge_filters
+# ---------------------------------------------------------------------------
+
+
+class TestMergeFilters:
+    def test_none_base_yields_extras(self) -> None:
+        merged = _merge_filters(
+            None,
+            extra_entity_types=("instrument",),
+            extra_entity_ids=(7, 9),
+        )
+        assert merged.entity_types == ("instrument",)
+        assert merged.entity_ids == (7, 9)
+
+    def test_unions_with_existing_filter(self) -> None:
+        base = SearchFilters(
+            year_min=2020,
+            entity_types=("mission",),
+            entity_ids=(1, 2),
+        )
+        merged = _merge_filters(
+            base,
+            extra_entity_types=("instrument", "mission"),
+            extra_entity_ids=(2, 3),
+        )
+        # Order-preserving union, deduped.
+        assert merged.entity_types == ("mission", "instrument")
+        assert merged.entity_ids == (1, 2, 3)
+        assert merged.year_min == 2020
+
+    def test_no_extras_returns_equivalent(self) -> None:
+        base = SearchFilters(year_max=2024, entity_types=("asteroid",))
+        merged = _merge_filters(base)
+        assert merged == base
+
+
+# ---------------------------------------------------------------------------
+# Ontology parser wiring
+# ---------------------------------------------------------------------------
+
+
+class TestOntologyParserWiring:
+    def _fake_lex(self, papers: list[dict]) -> SearchResult:
+        return SearchResult(papers=papers, total=len(papers), timing_ms={"lexical_ms": 0.1})
+
+    def test_lifts_entity_types_into_filters(self) -> None:
+        """entity_types from the parser should flow through to lexical_search filters."""
+        captured_filters: dict[str, SearchFilters | None] = {}
+
+        def fake_lex(conn, q, *, filters=None, limit=20, **kw):
+            captured_filters.setdefault("first", filters)
+            return SearchResult(papers=[], total=0, timing_ms={"lexical_ms": 0.1})
+
+        with (
+            patch("scix.search.lexical_search", side_effect=fake_lex),
+            patch("scix.search._model_has_embeddings", return_value=False),
+            patch(
+                "scix.search._resolve_entity_ids_for_properties",
+                return_value=(),
+            ),
+        ):
+            hybrid_search(
+                MagicMock(),
+                "infrared instruments on space telescopes",
+                enable_ontology_parser=True,
+                include_body=False,
+            )
+
+        f = captured_filters["first"]
+        assert f is not None
+        assert f.entity_types is not None
+        # parser yields 'instrument' and 'telescope' from the query
+        assert "instrument" in f.entity_types
+        assert "telescope" in f.entity_types
+
+    def test_resolves_properties_filter_to_entity_ids(self) -> None:
+        """A KNOWN_MISSIONS+entity_type query should resolve to entity_ids via DB lookup."""
+        captured: dict[str, SearchFilters | None] = {}
+
+        def fake_lex(conn, q, *, filters=None, limit=20, **kw):
+            captured.setdefault("first", filters)
+            return SearchResult(papers=[], total=0, timing_ms={"lexical_ms": 0.1})
+
+        with (
+            patch("scix.search.lexical_search", side_effect=fake_lex),
+            patch("scix.search._model_has_embeddings", return_value=False),
+            patch(
+                "scix.search._resolve_entity_ids_for_properties",
+                return_value=(101, 202),
+            ) as mock_resolve,
+        ):
+            result = hybrid_search(
+                MagicMock(),
+                "JWST instruments",
+                enable_ontology_parser=True,
+                include_body=False,
+            )
+
+        mock_resolve.assert_called_once()
+        f = captured["first"]
+        assert f is not None
+        assert f.entity_ids == (101, 202)
+        assert "instrument" in (f.entity_types or ())
+        assert result.metadata["ontology_clauses"] >= 2  # entity_type + properties clauses
+        assert result.metadata["ontology_entity_ids"] == 2
+
+    def test_no_clauses_skips_filter_mutation(self) -> None:
+        """A query with no ontology hooks should leave filters untouched."""
+        captured: dict[str, SearchFilters | None] = {}
+
+        def fake_lex(conn, q, *, filters=None, limit=20, **kw):
+            captured.setdefault("first", filters)
+            return SearchResult(papers=[], total=0, timing_ms={"lexical_ms": 0.1})
+
+        with (
+            patch("scix.search.lexical_search", side_effect=fake_lex),
+            patch("scix.search._model_has_embeddings", return_value=False),
+        ):
+            hybrid_search(
+                MagicMock(),
+                "dark matter haloes",
+                enable_ontology_parser=True,
+                include_body=False,
+            )
+
+        f = captured["first"]
+        assert f is None or (f.entity_types is None and f.entity_ids is None)
+
+
+# ---------------------------------------------------------------------------
+# Alias expansion wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_alias_cache() -> None:
+    clear_automaton_cache()
+    yield
+    clear_automaton_cache()
+
+
+def _build_test_automaton():
+    rows = [
+        EntityRow(
+            entity_id=1,
+            surface="JWST",
+            canonical_name="James Webb Space Telescope",
+            ambiguity_class="unambiguous",
+            is_alias=True,
+        ),
+        EntityRow(
+            entity_id=1,
+            surface="James Webb Space Telescope",
+            canonical_name="James Webb Space Telescope",
+            ambiguity_class="unambiguous",
+            is_alias=False,
+        ),
+        EntityRow(
+            entity_id=2,
+            surface="MIRI",
+            canonical_name="Mid-Infrared Instrument",
+            ambiguity_class="unambiguous",
+            is_alias=True,
+        ),
+        EntityRow(
+            entity_id=2,
+            surface="Mid-Infrared Instrument",
+            canonical_name="Mid-Infrared Instrument",
+            ambiguity_class="unambiguous",
+            is_alias=False,
+        ),
+    ]
+    return build_alias_automaton_from_rows(
+        rows,
+        entity_type_by_id={1: "telescope", 2: "instrument"},
+    )
+
+
+class TestAliasExpansionWiring:
+    def test_extra_lexical_lanes_added(self) -> None:
+        """Each matched entity contributes one extra lexical_search call (capped)."""
+        automaton = _build_test_automaton()
+
+        lane_queries: list[str] = []
+
+        def fake_lex(conn, q, *, filters=None, limit=20, **kw):
+            lane_queries.append(q)
+            return SearchResult(
+                papers=[{"bibcode": f"b/{q[:8]}", "score": 1.0}],
+                total=1,
+                timing_ms={"lexical_ms": 0.1},
+            )
+
+        with (
+            patch("scix.search.lexical_search", side_effect=fake_lex),
+            patch("scix.search._model_has_embeddings", return_value=False),
+        ):
+            result = hybrid_search(
+                MagicMock(),
+                "JWST MIRI imaging",
+                enable_alias_expansion=True,
+                alias_automaton=automaton,
+                include_body=False,
+            )
+
+        # First call is the original query; subsequent calls are the canonical
+        # lanes for matched entities.
+        assert lane_queries[0] == "JWST MIRI imaging"
+        canonical_lanes = lane_queries[1:]
+        assert "James Webb Space Telescope" in canonical_lanes
+        assert "Mid-Infrared Instrument" in canonical_lanes
+        assert result.metadata["alias_matches"] == 2
+        assert result.metadata["alias_lanes"] == 2
+
+    def test_lane_cap_respected(self) -> None:
+        """No more than _MAX_ALIAS_LEXICAL_LANES extra calls regardless of matches."""
+        from scix.search import _MAX_ALIAS_LEXICAL_LANES
+
+        # Build an automaton with more entities than the cap.
+        rows = []
+        type_map: dict[int, str] = {}
+        for eid in range(1, _MAX_ALIAS_LEXICAL_LANES + 3):
+            short = f"E{eid}"
+            canonical = f"Entity Number {eid}"
+            rows.append(
+                EntityRow(
+                    entity_id=eid,
+                    surface=short,
+                    canonical_name=canonical,
+                    ambiguity_class="unambiguous",
+                    is_alias=True,
+                )
+            )
+            rows.append(
+                EntityRow(
+                    entity_id=eid,
+                    surface=canonical,
+                    canonical_name=canonical,
+                    ambiguity_class="unambiguous",
+                    is_alias=False,
+                )
+            )
+            type_map[eid] = "thing"
+        automaton = build_alias_automaton_from_rows(rows, entity_type_by_id=type_map)
+
+        query = " ".join(f"E{eid}" for eid in range(1, _MAX_ALIAS_LEXICAL_LANES + 3))
+
+        lane_queries: list[str] = []
+
+        def fake_lex(conn, q, *, filters=None, limit=20, **kw):
+            lane_queries.append(q)
+            return SearchResult(papers=[], total=0, timing_ms={"lexical_ms": 0.1})
+
+        with (
+            patch("scix.search.lexical_search", side_effect=fake_lex),
+            patch("scix.search._model_has_embeddings", return_value=False),
+        ):
+            hybrid_search(
+                MagicMock(),
+                query,
+                enable_alias_expansion=True,
+                alias_automaton=automaton,
+                include_body=False,
+            )
+
+        # Original + at most _MAX_ALIAS_LEXICAL_LANES extras
+        assert len(lane_queries) == 1 + _MAX_ALIAS_LEXICAL_LANES
+
+    def test_no_matches_no_extra_lanes(self) -> None:
+        automaton = _build_test_automaton()
+
+        lane_queries: list[str] = []
+
+        def fake_lex(conn, q, *, filters=None, limit=20, **kw):
+            lane_queries.append(q)
+            return SearchResult(papers=[], total=0, timing_ms={"lexical_ms": 0.1})
+
+        with (
+            patch("scix.search.lexical_search", side_effect=fake_lex),
+            patch("scix.search._model_has_embeddings", return_value=False),
+        ):
+            result = hybrid_search(
+                MagicMock(),
+                "dark matter haloes",
+                enable_alias_expansion=True,
+                alias_automaton=automaton,
+                include_body=False,
+            )
+
+        assert lane_queries == ["dark matter haloes"]
+        assert result.metadata["alias_lanes"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Default-off contract
+# ---------------------------------------------------------------------------
+
+
+class TestFlagsDefaultOff:
+    def test_neither_flag_calls_extra_helpers(self) -> None:
+        """With both flags False (default), the new code paths must be silent."""
+        with (
+            patch("scix.search.lexical_search") as mock_lex,
+            patch("scix.search._model_has_embeddings", return_value=False),
+            patch("scix.search._resolve_entity_ids_for_properties") as mock_resolve,
+        ):
+            mock_lex.return_value = SearchResult(papers=[], total=0, timing_ms={"lexical_ms": 0.1})
+            result = hybrid_search(MagicMock(), "any query", include_body=False)
+
+        mock_resolve.assert_not_called()
+        # exactly one lexical call (the original query); no alias lanes
+        assert mock_lex.call_count == 1
+        assert "ontology_clauses" not in result.metadata
+        assert "alias_lanes" not in result.metadata
+
+
+# ---------------------------------------------------------------------------
+# Integration test (real DB, gated on SCIX_TEST_DSN)
+# ---------------------------------------------------------------------------
+
+
+class _RollbackFixture(Exception):
+    """Internal marker — raised inside the integration test's transaction so
+    psycopg rolls back the seeded fixture rows."""
+
+
+@pytest.mark.integration
+def test_hybrid_search_with_both_flags_against_scix_test() -> None:
+    """End-to-end: insert a couple of entities + papers, run hybrid_search with
+    both flags on, verify results return without error and the metadata
+    surfaces the new counters.
+    """
+    dsn = os.environ.get("SCIX_TEST_DSN")
+    if not dsn:
+        pytest.skip("SCIX_TEST_DSN not set")
+
+    import psycopg
+
+    from scix.alias_expansion import build_alias_automaton_from_rows
+
+    captured: dict[str, object] = {}
+
+    with psycopg.connect(dsn) as conn:
+        try:
+            with conn.transaction():
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "INSERT INTO entities (canonical_name, entity_type, source, properties) "
+                        "VALUES (%s, %s, %s, %s::jsonb) RETURNING id",
+                        (
+                            "James Webb Space Telescope",
+                            "telescope",
+                            "test_fixture_xz4_1",
+                            '{"mission": "JWST"}',
+                        ),
+                    )
+                    jwst_id = cur.fetchone()[0]
+                    cur.execute(
+                        "INSERT INTO entities (canonical_name, entity_type, source, properties) "
+                        "VALUES (%s, %s, %s, %s::jsonb) RETURNING id",
+                        (
+                            "Mid-Infrared Instrument",
+                            "instrument",
+                            "test_fixture_xz4_1",
+                            '{"mission": "JWST"}',
+                        ),
+                    )
+                    miri_id = cur.fetchone()[0]
+                    cur.executemany(
+                        "INSERT INTO entity_aliases (entity_id, alias, alias_source) "
+                        "VALUES (%s, %s, %s) ON CONFLICT DO NOTHING",
+                        [
+                            (jwst_id, "JWST", "test_fixture_xz4_1"),
+                            (jwst_id, "Webb", "test_fixture_xz4_1"),
+                            (miri_id, "MIRI", "test_fixture_xz4_1"),
+                        ],
+                    )
+
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT id, canonical_name, entity_type FROM entities " "WHERE source = %s",
+                        ("test_fixture_xz4_1",),
+                    )
+                    ents = cur.fetchall()
+                    cur.execute(
+                        "SELECT entity_id, alias FROM entity_aliases " "WHERE entity_id = ANY(%s)",
+                        ([e[0] for e in ents],),
+                    )
+                    aliases = cur.fetchall()
+
+                type_map = {e[0]: e[2] for e in ents}
+                rows = []
+                for eid, canonical, _etype in ents:
+                    rows.append(
+                        EntityRow(
+                            entity_id=eid,
+                            surface=canonical,
+                            canonical_name=canonical,
+                            ambiguity_class="unambiguous",
+                            is_alias=False,
+                        )
+                    )
+                for eid, alias in aliases:
+                    canonical = next(c for i, c, _ in ents if i == eid)
+                    rows.append(
+                        EntityRow(
+                            entity_id=eid,
+                            surface=alias,
+                            canonical_name=canonical,
+                            ambiguity_class="unambiguous",
+                            is_alias=True,
+                        )
+                    )
+                automaton = build_alias_automaton_from_rows(rows, entity_type_by_id=type_map)
+
+                result = hybrid_search(
+                    conn,
+                    "JWST MIRI instruments",
+                    enable_alias_expansion=True,
+                    enable_ontology_parser=True,
+                    alias_automaton=automaton,
+                    include_body=False,
+                    top_n=5,
+                )
+                captured["result"] = result
+                # Force the transaction to roll back; psycopg treats any
+                # exception inside `conn.transaction()` as a rollback signal.
+                raise _RollbackFixture()
+        except _RollbackFixture:
+            pass
+
+    result = captured["result"]
+    # The query carries:
+    #   - 2 alias surface matches (JWST + MIRI)
+    #   - 1 entity-type clause ("instruments" -> 'instrument')
+    #   - 1 properties-filter clause (JWST + entity-type co-occurrence
+    #     -> {"mission": "JWST"}) which resolves to entity_ids on the fixture.
+    assert isinstance(result, SearchResult)
+    assert result.metadata.get("alias_matches", 0) >= 2
+    assert result.metadata.get("ontology_clauses", 0) >= 2
+    assert result.metadata.get("ontology_entity_ids", 0) >= 1


### PR DESCRIPTION
## Summary

Two query-time entity-aware modules wired into `hybrid_search` behind feature flags (default off):

- **`scix.alias_expansion`** (xz4.1.24) — given a free-text query, finds entity surface forms via an Aho-Corasick automaton built from `entities` + `entity_aliases`, returns canonical names + alias lists + entity_ids. Reuses the long-form disambiguator rule from `scix.aho_corasick` with a relaxation: unambiguous surfaces always fire (queries lack abstract-length disambiguation context).
- **`scix.ontology_query_parser`** (xz4.1.25) — pure local parser (no DB, no LLM) that lifts ontology fragments to retrieval filters. Hand-rolled tokenizer + small curated vocabulary (`ENTITY_TYPE_TERMS`, `KNOWN_MISSIONS`, asteroid taxonomy regex). Examples:
  - `"JWST instruments"` → `entity_type='instrument'` + `properties @> '{"mission": "JWST"}'`
  - `"M-type asteroid spectroscopy"` → `entity_type='asteroid'` + `properties @> '{"taxonomy": "M"}'`
  - `"flagship NASA missions"` → `entity_type='mission'`

Wiring in `hybrid_search`:
- **Ontology parser** lifts `entity_types` directly into `SearchFilters` and resolves `properties_filters` to `entity_ids` via a single bounded `entities` query (capped at 200 ids).
- **Alias expansion** adds up to **3 extra lexical RRF lanes** (one per matched entity, queried by canonical name) — *not* injected into the filter, since an entity_id filter would over-restrict recall. The lanes are fused via the existing RRF stage.

## Benchmark — `results/entity_query_expansion/run_2026-04-20.json`

10 queries (4 alias-heavy, 4 ontology-heavy, 2 mixed) drawn from `src/scix/eval/prompts/calibration_queries.yaml`. Compared 4 variants vs a kitchen-sink RRF oracle (both flags on, `lexical_limit=200`, `top_k=30`, reciprocal-rank grading).

| Variant   | nDCG@10 | Median nDCG@10 | Mean latency |
|-----------|---------|----------------|--------------|
| baseline  | 0.5750  | 0.7491         | 211 ms       |
| alias     | 0.5731  | 0.7363         | 3,764 ms     |
| ontology  | **0.6880**  | **0.9868**         | **138 ms**       |
| both      | 0.6887  | 0.9905         | 15,193 ms    |

Per-query nDCG@10 (selected):

| Query                                                              | baseline | alias | ontology | both |
|--------------------------------------------------------------------|----------|-------|----------|------|
| `infrared instruments on space telescopes for exoplanet detection` | 0.26     | 0.26  | **1.00** | 1.00 |
| `flagship NASA missions to the outer solar system`                 | 0.59     | 0.57  | **0.98** | 0.98 |
| `HST observations of cool brown dwarfs`                            | 1.00     | 1.00  | 1.00     | 1.00 |
| `Cassini spacecraft instruments at Saturn`                         | 1.00     | 1.00  | 1.00     | 1.00 |

**Headline finding:** ontology parser is the win — +11.3 mean nDCG points, *and* lower latency than baseline (the entity_type filter narrows the result set so RRF has fewer candidates). Wins concentrate on queries where the parser actually fires (queries containing entity-type words like "instruments", "missions"); on alias-heavy queries the lexical baseline already finds the right papers via tsvector context, so alias expansion is a wash.

## Known Limitations

1. **Planner pathology on multi-type lifts.** When the ontology parser lifts ≥2 `entity_types` into filters (e.g., `'instrument' + 'telescope' + 'exoplanet'`), the resulting EXISTS-on-MV clause in `lexical_search` falls off the index and times out on the 32M-paper corpus. The benchmark catches this via per-call `statement_timeout` (30s variant / 60s oracle); production callers should expect the same failure mode and either:
   - Use the `entity_types` filter only with a narrow seed set, OR
   - Wait for a follow-up that routes wide entity-type filters through `_filter_first_vector_search`-style cardinality-aware planning.

2. **Alias automaton noise.** Scoping the automaton to a small set of entity types still surfaces noisy aliases (e.g., `"Telescopes"`, institutional codes like `"CA/STATSCAN/AS/ON"`) that match generic query terms. Hybrid_search swallows the resulting failed lane queries and continues. Quality cleanup is a follow-up for the entity-aliases harvest pipeline, not this PR.

3. **Self-referential oracle.** The benchmark uses `hybrid_search(both flags ON)` as the relevance oracle. This rewards variants that recover the full-signal top-K but doesn't measure topical relevance. Per memory `feedback_entity_eval_methodology` and `feedback_claude_judge_via_oauth`, the proper topical eval requires the persona-Claude judge harness — that's the next bead, not this one.

4. **Coverage signal degenerate.** `entity_coverage_top10` is identical (0.0125) across all variants, suggesting the metric is dominated by a single overlapping paper across queries. Useful diagnostic but doesn't differentiate variants here.

## Test Plan

- [x] `pytest tests/test_alias_expansion.py` — 15 unit + 1 integration (rolled-back fixture on `scix_test`)
- [x] `pytest tests/test_ontology_query_parser.py` — 28 unit tests (incl. hypothesis property test for determinism)
- [x] `pytest tests/test_search_query_intent.py` — 10 unit + 1 integration (full hybrid_search wiring on `scix_test`)
- [x] `pytest tests/test_search.py` — 130 existing tests still pass (1 skipped)
- [x] `ruff check` clean on new modules + tests (one pre-existing E501 in untouched section of search.py)
- [x] `black --check` clean
- [x] Benchmark runs end-to-end without manual intervention (statement_timeout safety net)
- [x] Production DB only read (no INSERT/UPDATE/DELETE outside the rolled-back integration fixture)

## Files Changed

- `src/scix/alias_expansion.py` (493 lines) — new
- `src/scix/ontology_query_parser.py` (341 lines) — new
- `src/scix/search.py` (+162 lines) — wired both flags, added `_merge_filters` + `_resolve_entity_ids_for_properties`
- `tests/test_alias_expansion.py` (369 lines) — new
- `tests/test_ontology_query_parser.py` (230 lines) — new
- `tests/test_search_query_intent.py` (468 lines) — new
- `scripts/bench_entity_query_expansion.py` (430 lines) — new
- `results/entity_query_expansion/run_2026-04-20.json` — new

## Beads

Refs: `scix_experiments-xz4.1.24` (alias expansion), `scix_experiments-xz4.1.25` (ontology parser). Both still open in beads — bd CLI is currently broken on this checkout (`table not found: wisps` schema mismatch with the on-disk dolt server), so beads will need manual close after merge.