### PR TITLE
feat(storage): halfvec(768) shadow column for INDUS — bead 0vy

### DIFF
--- a/docs/runbooks/halfvec_migration.md
+++ b/docs/runbooks/halfvec_migration.md
@@ -1,0 +1,312 @@
+# Runbook — paper_embeddings halfvec migration
+
+**Bead**: `scix_experiments-0vy`
+**Branch**: `storage/halfvec-migration`
+**Goal**: migrate the 32.4M INDUS rows in `paper_embeddings.embedding`
+  (float32 `vector(768)`) onto a `halfvec(768)` column + matching HNSW
+  index, cutting index footprint ≥40% while preserving nDCG@10/Recall@10
+  on the 50-query eval.
+
+---
+
+## 0. Architectural decision — Option B (shadow column)
+
+We considered two paths:
+
+| Option | Approach | Pros | Cons |
+|---|---|---|---|
+| A | `ALTER TABLE ... ALTER COLUMN embedding TYPE halfvec(768) USING ...` | Single DDL; no code changes beyond cast literal. | ACCESS EXCLUSIVE on the table for the full rewrite (~hours on 32M rows / 125 GB TOAST), blocks `scripts/embed.py` daily cron, single-shot failure rolls the whole thing back. |
+| B | Add `embedding_hv halfvec(768)` shadow column, backfill in batches, build new HNSW, cut code over, drop old column later. | Online. Batches checkpoint. Rollback = don't deploy code. Survives OOM kills. | More code (column-aware casts in `search.py`, dual write in `embed.py`). Doubles storage during transition. |
+
+**Chose B.** Online-ness matters more than code simplicity on a 253 GB table
+with a daily embed pipeline. The added TOAST during transition (~125 GB)
+is recovered in phase 5 when the legacy column is dropped.
+
+---
+
+## 1. Pre-flight checks
+
+Run these as `ds` on the scix host, **before** starting the migration:
+
+```bash
+# 1. M3 community recompute has completed.
+#    Must see count(community_id_fine) >= 19M AND no live
+#    recompute_citation_communities.py process.
+psql "$SCIX_DSN" -c "SELECT count(community_id_fine) FROM paper_metrics;"
+pgrep -af recompute_citation_communities.py || echo "M3 idle ✓"
+
+# 2. pgvector >= 0.8.2 and halfvec opclass available.
+psql "$SCIX_DSN" -c "SELECT extversion FROM pg_extension WHERE extname='vector';"
+psql "$SCIX_DSN" -c "SELECT opcname FROM pg_opclass WHERE opcname='halfvec_cosine_ops';"
+
+# 3. Disk headroom on /var/lib/postgresql (or wherever PGDATA lives).
+#    Need ~130 GB free during backfill (shadow column TOAST) + ~60 GB for new index.
+df -h /var/lib/postgresql
+
+# 4. scix-batch wrapper is on PATH.
+command -v scix-batch
+
+# 5. Current embed.py cron is quiet (won't contend on writes).
+systemctl list-timers | grep -i embed || crontab -l | grep embed
+
+# 6. Baseline index size captured.
+psql "$SCIX_DSN" -c "\
+  SELECT indexname, pg_size_pretty(pg_relation_size(indexname::regclass)) \
+    FROM pg_indexes WHERE tablename='paper_embeddings';"
+```
+
+Save the pre-migration sizes to
+`results/halfvec_migration/sizes_before.txt`.
+
+---
+
+## 2. Baseline eval (pre-migration)
+
+```bash
+scix-batch python scripts/eval_retrieval_50q.py \
+    --full-corpus \
+    --seed-papers 50 \
+    --random-seed 42 \
+    --json-output results/halfvec_migration/baseline.json \
+    --output      results/halfvec_migration/baseline.md
+```
+
+This runs the citation-based 50-query harness (Section 4.4 of the paper)
+against the full 32.4M corpus with `random_seed=42` so pre/post use the
+same seed papers + ground-truth citation sets. Methods include
+`indus`, `lexical`, and `hybrid_indus` by default under `--full-corpus`.
+
+Capture `nDCG@10`, `Recall@10`, `Recall@20`, `MRR` per method plus the
+timing histograms the harness prints. Paste them into
+`results/halfvec_migration/baseline.json` (the harness writes it).
+
+---
+
+## 3. Schema prep — migration 053
+
+Apply the "add shadow column" migration:
+
+```bash
+scix-batch psql "$SCIX_DSN" -v ON_ERROR_STOP=1 \
+    -f migrations/053_paper_embeddings_halfvec.sql
+```
+
+This is metadata-only: `ALTER TABLE ... ADD COLUMN ... halfvec(768)`
+doesn't rewrite data. Takes < 1 s even on 32M rows.
+
+**Verify**:
+```bash
+psql "$SCIX_DSN" -c "\\d paper_embeddings" | grep embedding_hv
+psql "$SCIX_DSN" -c "SELECT count(*) FROM halfvec_backfill_progress;"
+```
+
+---
+
+## 4. Backfill — scripts/backfill_halfvec.py
+
+Populates `embedding_hv` for all `model_name='indus'` rows. Idempotent,
+batched (default 20k/batch), signal-safe (SIGTERM finishes current batch).
+
+```bash
+scix-batch --mem-high 10G --mem-max 15G \
+    python scripts/backfill_halfvec.py \
+        --dsn "$SCIX_DSN" \
+        --model indus \
+        --batch-size 20000 \
+        2>&1 | tee logs/halfvec_backfill.log
+```
+
+**Estimated runtime**: 32.4M rows / 20k batch = ~1600 batches. At an
+expected ~500k rows/s (pure SQL cast, no network round-trip), wall clock
+is ~60-90 minutes. Dominated by WAL write + TOAST rewrite.
+
+**Monitoring** (from another tmux pane):
+```bash
+watch -n 30 'psql "$SCIX_DSN" -c "
+    SELECT rows_updated, last_bibcode, updated_at
+      FROM halfvec_backfill_progress
+     ORDER BY started_at DESC LIMIT 1;"'
+```
+
+**Resumption**: if the script is killed, re-run the same command. It
+reads the open progress row and continues from `last_bibcode`.
+
+**Completion check**:
+```bash
+psql "$SCIX_DSN" -c "
+    SELECT count(*) FILTER (WHERE embedding_hv IS NULL) AS missing
+      FROM paper_embeddings WHERE model_name='indus';"
+# Expect 0
+```
+
+---
+
+## 5. New HNSW index — migration 054
+
+Built with `CREATE INDEX CONCURRENTLY` so reads + writes continue.
+
+```bash
+scix-batch --mem-high 20G --mem-max 30G \
+    psql "$SCIX_DSN" -v ON_ERROR_STOP=1 \
+        -f migrations/054_paper_embeddings_halfvec_index.sql \
+        2>&1 | tee logs/halfvec_index_build.log
+```
+
+**Estimated runtime**: 45-90 minutes on this host
+(maintenance_work_mem=8GB, max_parallel_maintenance_workers=7).
+
+**Monitor progress** (from another pane):
+```bash
+psql "$SCIX_DSN" -c "
+    SELECT phase, round(100 * blocks_done::numeric / blocks_total, 1) AS pct
+      FROM pg_stat_progress_create_index;"
+```
+
+**Expected final size**: ~60 GB (half of the 120 GB `vector_cosine_ops`
+index — halfvec is 2 bytes/dim instead of 4).
+
+**If the build fails partway** (leaves an INVALID index):
+```bash
+psql "$SCIX_DSN" -c "DROP INDEX CONCURRENTLY IF EXISTS idx_embed_hnsw_indus_hv;"
+# Then re-run migration 054.
+```
+
+---
+
+## 6. Code cutover
+
+Deploy this PR (`storage/halfvec-migration`). The only runtime changes:
+
+- `src/scix/search.py` — `vector_search` / `_filter_first_vector_search`
+  route INDUS queries to `pe.embedding_hv <=> $1::halfvec(768)` against
+  `idx_embed_hnsw_indus_hv`. Pilot models unaffected.
+- `src/scix/embed.py` — INDUS writes populate `embedding_hv`
+  (`embedding` stays NULL for new INDUS rows); pilots unchanged.
+
+Verify in dev:
+
+```bash
+python -c "
+from scix.db import get_connection
+from scix.search import vector_search
+conn = get_connection()
+import random
+vec = [random.random() for _ in range(768)]
+r = vector_search(conn, vec, model_name='indus', limit=5)
+for p in r.papers: print(p['bibcode'], p['score'])
+"
+```
+
+Then restart the MCP server so it picks up the new code:
+
+```bash
+cd ~/projects/scix_experiments
+./deploy/run.sh  # rebuild image + restart
+curl -sf https://mcp.sjarmak.ai/health
+```
+
+---
+
+## 7. Post-migration eval
+
+Re-run the 50-query eval against the new index and diff. The `--random-seed
+42` flag is critical — it guarantees the same seed papers so paired stats
+are valid:
+
+```bash
+scix-batch python scripts/eval_retrieval_50q.py \
+    --full-corpus \
+    --seed-papers 50 \
+    --random-seed 42 \
+    --json-output results/halfvec_migration/post.json \
+    --output      results/halfvec_migration/post.md
+
+python - <<'PY'
+import json, pathlib
+base = json.loads(pathlib.Path('results/halfvec_migration/baseline.json').read_text())
+post = json.loads(pathlib.Path('results/halfvec_migration/post.json').read_text())
+def summarize(doc):
+    return {m['method']: m for m in doc.get('summaries', [])}
+bs, ps = summarize(base), summarize(post)
+for method in sorted(set(bs) | set(ps)):
+    b, p = bs.get(method, {}), ps.get(method, {})
+    for k in ('ndcg_at_10','recall_at_10','recall_at_20','mrr'):
+        bv, pv = b.get(k), p.get(k)
+        if bv is None or pv is None: continue
+        print(f"{method:18s} {k:15s} base={bv:.4f} post={pv:.4f} delta={pv - bv:+.4f}")
+PY
+```
+
+**Acceptance gates**:
+- `ΔnDCG@10`  ≥ -0.005  (≤ 0.5 pt drop)
+- `ΔRecall@10`  ≥ -0.01
+- `p50_ms_post` ≤ `p50_ms_base * 1.20` (expect improvement — smaller index = better cache locality)
+
+If any gate fails: **do not drop the old index**. Fall back by reverting
+the PR; the old `idx_embed_hnsw_indus` and `embedding` column are still
+present and queries revert seamlessly.
+
+---
+
+## 8. Index footprint verification
+
+```bash
+psql "$SCIX_DSN" -c "
+    SELECT indexname, pg_size_pretty(pg_relation_size(indexname::regclass)) AS size
+      FROM pg_indexes
+     WHERE tablename='paper_embeddings'
+       AND indexname LIKE 'idx_embed_hnsw_indus%';"
+```
+
+Write the comparison to `results/halfvec_migration/sizes_after.txt` and
+confirm `idx_embed_hnsw_indus_hv` is ≥40% smaller than the pre-migration
+`idx_embed_hnsw_indus`.
+
+---
+
+## 9. Cleanup (later, gated on stability)
+
+After the new index runs clean for a week:
+
+1. New migration `055_drop_legacy_indus_embedding.sql`:
+   ```sql
+   DROP INDEX CONCURRENTLY IF EXISTS idx_embed_hnsw_indus;
+   -- The column stays: paper_embeddings_nomic/_specter2 pilots still
+   -- use `embedding`. Column drop is a separate follow-up once pilots
+   -- are retired (see bead scix_experiments-2xe successors).
+   ```
+2. `VACUUM (ANALYZE, VERBOSE) paper_embeddings;` to reclaim TOAST space
+   left over from the now-unused `embedding` values in INDUS rows.
+
+---
+
+## 10. Rollback
+
+| Stage reached | Rollback |
+|---|---|
+| Migration 053 only | `ALTER TABLE paper_embeddings DROP COLUMN embedding_hv; DROP TABLE halfvec_backfill_progress;` |
+| Backfill partially complete | Same as above — `embedding_hv` column drop takes everything with it. |
+| Index 054 built, code not deployed | `DROP INDEX CONCURRENTLY idx_embed_hnsw_indus_hv;` then column drop as above. |
+| Code deployed, eval regression | `git revert` the PR, redeploy. Old index and column are intact. |
+| Post-cleanup (055) | Out of rollback window — would need to rebuild `idx_embed_hnsw_indus` from scratch (~8h) against the surviving `embedding` values. This is why we wait a week before 055. |
+
+---
+
+## 11. Known risks
+
+- **TOAST bloat during backfill.** Every `UPDATE` writes a new TOAST row
+  for `embedding_hv`. `paper_embeddings` hasn't been VACUUM-FULLed in
+  ages; partial vacuums happen via autovacuum. If bloat becomes a
+  concern mid-run, pause the backfill and run a targeted
+  `VACUUM (ANALYZE) paper_embeddings` between batches.
+- **HNSW build memory.** `maintenance_work_mem=8GB` × 7 workers can
+  theoretically hit 56 GB peak. Keep the scix-batch memory limits in
+  phase 5; the per-worker allocation is usually far below the limit
+  because vectors are only 768×2 bytes = 1.5 KB each.
+- **Concurrent M3 recompute.** Do not start at the same time as
+  `scripts/recompute_citation_communities.py` — they compete for I/O
+  and M3 is the OOM-kill priority target at ~34 GB RSS.
+- **Query regression in iterative_scan.** pgvector 0.8's iterative scan
+  is validated on `vector_cosine_ops`; halfvec_cosine_ops uses the same
+  code path but we have no historical data. The 50-query eval in
+  phase 7 is the guardrail.

--- a/migrations/053_paper_embeddings_halfvec.sql
+++ b/migrations/053_paper_embeddings_halfvec.sql
@@ -1,0 +1,98 @@
+-- migration: 053_paper_embeddings_halfvec — halfvec storage for INDUS
+--
+-- Bead: scix_experiments-0vy
+-- PRD/notes: docs/runbooks/halfvec_migration.md
+--
+-- This migration is the ONLINE (shadow-column) leg of the halfvec cutover.
+-- It deliberately does NOT rewrite the existing `embedding` column, because
+-- ALTER COLUMN ... TYPE halfvec(768) USING ... holds ACCESS EXCLUSIVE on
+-- paper_embeddings for the entire rewrite (~multi-hour on 32M rows / 125 GB
+-- TOAST) and would block the daily embed.py cron. Instead we add a nullable
+-- halfvec(768) shadow column and backfill it out-of-band in batches via
+-- scripts/backfill_halfvec.py. The new HNSW index is built separately
+-- (CREATE INDEX CONCURRENTLY cannot run inside a transaction) — see
+-- migration 054 and the runbook for the full sequence.
+--
+-- Idempotent: every DDL uses IF NOT EXISTS. Safe to re-run.
+--
+-- Dependencies:
+--   - paper_embeddings exists (migrations 001 / 004 / 005).
+--   - pgvector >= 0.8.0 (migration 005 upgraded to 0.8.2).
+--   - halfvec type + halfvec_cosine_ops opclass (shipped with pgvector 0.7+).
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. Shadow column: embedding_hv halfvec(768)
+-- ---------------------------------------------------------------------------
+-- Nullable so the ALTER is metadata-only (no rewrite, no lock scan). The
+-- backfill script populates it for model_name='indus' rows. The pilot
+-- embeddings (nomic, specter2) stay on the legacy vector column — per bead
+-- 0vy non-goals they are not being migrated.
+
+ALTER TABLE paper_embeddings
+    ADD COLUMN IF NOT EXISTS embedding_hv halfvec(768);
+
+COMMENT ON COLUMN paper_embeddings.embedding_hv IS
+    'halfvec(768) shadow column for INDUS. Populated by '
+    'scripts/backfill_halfvec.py and by scripts/embed.py on new writes. '
+    'Replaces (embedding::vector(768)) as the canonical retrieval column '
+    'for model_name=''indus''. Pilot models keep using embedding.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Progress-tracking table for the backfill
+-- ---------------------------------------------------------------------------
+-- The backfill is batched by bibcode range so restarts are cheap. We persist
+-- cursor + counts here so the script is idempotent across OOM kills and
+-- systemd scope restarts.
+
+CREATE TABLE IF NOT EXISTS halfvec_backfill_progress (
+    id             SERIAL PRIMARY KEY,
+    model_name     TEXT NOT NULL,
+    last_bibcode   TEXT,
+    rows_updated   BIGINT NOT NULL DEFAULT 0,
+    started_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at    TIMESTAMPTZ,
+    note           TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_halfvec_backfill_progress_model
+    ON halfvec_backfill_progress (model_name, started_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- 3. Assertion: column is present with the expected type
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+    col_type TEXT;
+BEGIN
+    SELECT format_type(atttypid, atttypmod)
+      INTO col_type
+      FROM pg_attribute
+     WHERE attrelid = 'paper_embeddings'::regclass
+       AND attname  = 'embedding_hv';
+
+    IF col_type IS NULL THEN
+        RAISE EXCEPTION 'migration 053: embedding_hv column not added';
+    END IF;
+    IF col_type <> 'halfvec(768)' THEN
+        RAISE EXCEPTION 'migration 053: embedding_hv has unexpected type %', col_type;
+    END IF;
+END $$;
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+-- NEXT STEPS (executed outside this file — see docs/runbooks/halfvec_migration.md)
+-- ---------------------------------------------------------------------------
+--   1. scix-batch python scripts/backfill_halfvec.py --model indus --dsn "$SCIX_DSN"
+--        → populates embedding_hv for all existing indus rows
+--   2. migration 054_paper_embeddings_halfvec_index.sql  (CREATE INDEX CONCURRENTLY)
+--        → builds idx_embed_hnsw_indus_hv on embedding_hv halfvec_cosine_ops
+--   3. Deploy src/scix/search.py + scripts/embed.py changes
+--        → queries and new writes cut over to embedding_hv
+--   4. Smoke-test 50-query eval (results/halfvec_migration/post.json)
+--   5. Later migration to DROP INDEX idx_embed_hnsw_indus + DROP COLUMN embedding
+--        (paper_embeddings_nomic / _specter2 also read embedding — gated on
+--         retiring those pilots).

--- a/migrations/054_paper_embeddings_halfvec_index.sql
+++ b/migrations/054_paper_embeddings_halfvec_index.sql
@@ -1,0 +1,48 @@
+-- migration: 054_paper_embeddings_halfvec_index — HNSW on embedding_hv
+--
+-- Bead: scix_experiments-0vy
+-- Prereq: migration 053 applied; scripts/backfill_halfvec.py --model indus
+--         has completed for at least the rows you want indexed.
+--
+-- This migration creates the new partial HNSW index on the halfvec(768)
+-- shadow column. The old index (idx_embed_hnsw_indus on vector_cosine_ops)
+-- is NOT dropped here — the code deploy (src/scix/search.py) cuts queries
+-- over to the new column, then a follow-up migration drops the old index
+-- once the cutover is verified on the 50-query eval.
+--
+-- CREATE INDEX CONCURRENTLY cannot run inside a transaction. Psycopg-based
+-- migration runners in this repo (scripts/migrate.py) accept files without
+-- BEGIN/COMMIT and execute them with autocommit; verify that before running.
+--
+-- Runtime / resources (estimate on this host, per scix_test dry-run):
+--   - Build time: ~45-90 minutes wall clock for 32M halfvec(768) rows.
+--   - Peak RAM: ~10-15 GB (parallel workers × maintenance_work_mem).
+--   - Disk: ~60 GB new index (~half of the 120 GB vector_cosine_ops index).
+--   - MUST be invoked via scix-batch to keep user@1000.service OOM isolation.
+--     Recommended: scix-batch --mem-high 20G --mem-max 30G psql "$SCIX_DSN" \
+--         -v ON_ERROR_STOP=1 -f migrations/054_paper_embeddings_halfvec_index.sql
+
+SET maintenance_work_mem = '8GB';
+SET max_parallel_maintenance_workers = 7;
+
+-- NOTE on the partial-index predicate: we intentionally match the shape of
+-- the legacy idx_embed_hnsw_indus (WHERE model_name='indus', no NOT NULL
+-- clause) so the planner can match index-to-query by lexical predicate
+-- equality. pgvector's HNSW silently skips NULL rows at build time, so
+-- indexing partially-backfilled state is safe — the index just grows
+-- incrementally as the backfill progresses.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_embed_hnsw_indus_hv
+    ON paper_embeddings
+    USING hnsw (embedding_hv halfvec_cosine_ops)
+    WITH (m = 16, ef_construction = 64)
+    WHERE model_name = 'indus';
+
+-- If CREATE INDEX CONCURRENTLY fails midway, the index is left INVALID.
+-- Drop it and retry:
+--     DROP INDEX CONCURRENTLY IF EXISTS idx_embed_hnsw_indus_hv;
+--
+-- Post-verification (also encoded in tests/test_halfvec_migration.py):
+--     SELECT indexname, pg_size_pretty(pg_relation_size(indexname::regclass))
+--       FROM pg_indexes
+--      WHERE tablename='paper_embeddings'
+--        AND indexname LIKE 'idx_embed_hnsw_indus%';

--- a/scripts/backfill_halfvec.py
+++ b/scripts/backfill_halfvec.py
@@ -1,0 +1,331 @@
+"""Backfill paper_embeddings.embedding_hv (halfvec(768)) from embedding (vector).
+
+Bead: scix_experiments-0vy.
+
+This is the long-running leg of the halfvec migration (Option B, shadow
+column). It batches over paper_embeddings in bibcode-order for
+model_name='indus', casts the stored vector to halfvec(768), and writes the
+result to embedding_hv. Progress is persisted in halfvec_backfill_progress
+so restarts are cheap.
+
+MUST be invoked via scix-batch so that user@1000.service OOM pressure does
+not target the gascity supervisor:
+
+    scix-batch python scripts/backfill_halfvec.py \
+        --dsn "$SCIX_DSN" --model indus --batch-size 20000
+
+Design notes
+------------
+- The UPDATE is guarded by `embedding_hv IS NULL` so re-runs skip already-
+  migrated rows. This also makes the script safe to run concurrently with
+  scripts/embed.py (new INDUS rows land with embedding_hv already set by
+  the updated embed.py writer path; legacy rows get backfilled here).
+- Batches are bounded by bibcode range (not LIMIT/OFFSET) so each batch
+  takes a narrow, predictable lock window and does not rely on a stable
+  row order across transactions.
+- We commit after every batch to keep WAL pressure bounded. A batch of
+  20k halfvec(768) rows writes ~30 MB of TOAST which is comfortably under
+  a single checkpoint cycle.
+- No paid-API dependencies. This is pure SQL: the cast happens inside
+  postgres via `embedding::halfvec(768)`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import signal
+import sys
+import time
+from dataclasses import dataclass
+
+import psycopg
+
+logger = logging.getLogger("halfvec_backfill")
+
+
+@dataclass(frozen=True)
+class BackfillConfig:
+    dsn: str
+    model_name: str
+    batch_size: int
+    max_batches: int | None
+    resume: bool
+    dry_run: bool
+
+
+_STOP = False
+
+
+def _install_signal_handler() -> None:
+    def _handle(signum: int, _frame: object) -> None:  # noqa: ARG001
+        global _STOP
+        logger.warning("Received signal %s — will stop after current batch", signum)
+        _STOP = True
+
+    signal.signal(signal.SIGTERM, _handle)
+    signal.signal(signal.SIGINT, _handle)
+
+
+def _fetch_progress_cursor(conn: psycopg.Connection, model_name: str) -> tuple[int, str | None]:
+    """Return (progress_row_id, last_bibcode) for the most recent open run."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, last_bibcode
+              FROM halfvec_backfill_progress
+             WHERE model_name = %s AND finished_at IS NULL
+             ORDER BY started_at DESC
+             LIMIT 1
+            """,
+            (model_name,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return (_open_progress_row(conn, model_name), None)
+    return (row[0], row[1])
+
+
+def _open_progress_row(conn: psycopg.Connection, model_name: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO halfvec_backfill_progress (model_name)
+            VALUES (%s)
+            RETURNING id
+            """,
+            (model_name,),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    assert row is not None
+    return int(row[0])
+
+
+def _update_progress(
+    conn: psycopg.Connection,
+    progress_id: int,
+    last_bibcode: str,
+    delta_rows: int,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE halfvec_backfill_progress
+               SET last_bibcode = %s,
+                   rows_updated = rows_updated + %s,
+                   updated_at   = now()
+             WHERE id = %s
+            """,
+            (last_bibcode, delta_rows, progress_id),
+        )
+
+
+def _close_progress_row(conn: psycopg.Connection, progress_id: int, note: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE halfvec_backfill_progress
+               SET finished_at = now(),
+                   note        = %s
+             WHERE id = %s
+            """,
+            (note, progress_id),
+        )
+    conn.commit()
+
+
+def _count_remaining(conn: psycopg.Connection, model_name: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT count(*)
+              FROM paper_embeddings
+             WHERE model_name = %s
+               AND embedding     IS NOT NULL
+               AND embedding_hv  IS NULL
+            """,
+            (model_name,),
+        )
+        row = cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+def _run_batch(
+    conn: psycopg.Connection,
+    model_name: str,
+    cursor_bibcode: str | None,
+    batch_size: int,
+    dry_run: bool,
+) -> tuple[int, str | None]:
+    """Update one batch. Returns (rows_updated, new_cursor_bibcode)."""
+    # Use a CTE so we know the exact max(bibcode) touched — this is our new
+    # cursor. Without RETURNING we'd have to re-query for it.
+    sql = """
+        WITH batch AS (
+            SELECT bibcode
+              FROM paper_embeddings
+             WHERE model_name = %(model)s
+               AND embedding     IS NOT NULL
+               AND embedding_hv  IS NULL
+               AND (%(cursor)s::text IS NULL OR bibcode > %(cursor)s::text)
+             ORDER BY bibcode
+             LIMIT %(limit)s
+        ),
+        upd AS (
+            UPDATE paper_embeddings pe
+               SET embedding_hv = pe.embedding::halfvec(768)
+              FROM batch b
+             WHERE pe.bibcode    = b.bibcode
+               AND pe.model_name = %(model)s
+            RETURNING pe.bibcode
+        )
+        SELECT count(*)::bigint AS updated,
+               max(bibcode)     AS max_bibcode
+          FROM upd;
+    """
+    params = {
+        "model": model_name,
+        "cursor": cursor_bibcode,
+        "limit": batch_size,
+    }
+
+    if dry_run:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT count(*)::bigint, max(bibcode)
+                  FROM (
+                    SELECT bibcode
+                      FROM paper_embeddings
+                     WHERE model_name = %(model)s
+                       AND embedding     IS NOT NULL
+                       AND embedding_hv  IS NULL
+                       AND (%(cursor)s::text IS NULL OR bibcode > %(cursor)s::text)
+                     ORDER BY bibcode
+                     LIMIT %(limit)s
+                  ) q
+                """,
+                params,
+            )
+            row = cur.fetchone()
+        conn.rollback()
+        return (int(row[0]), row[1]) if row else (0, None)
+
+    with conn.cursor() as cur:
+        cur.execute(sql, params)
+        row = cur.fetchone()
+    conn.commit()
+    if row is None or row[0] == 0:
+        return (0, None)
+    return (int(row[0]), row[1])
+
+
+def run(cfg: BackfillConfig) -> int:
+    logger.info(
+        "halfvec backfill starting — model=%s batch=%d dry_run=%s",
+        cfg.model_name,
+        cfg.batch_size,
+        cfg.dry_run,
+    )
+
+    with psycopg.connect(cfg.dsn) as conn:
+        remaining_before = _count_remaining(conn, cfg.model_name)
+        logger.info("rows pending backfill: %d", remaining_before)
+        if remaining_before == 0:
+            logger.info("nothing to do — all rows already have embedding_hv")
+            return 0
+
+        progress_id, cursor_bibcode = _fetch_progress_cursor(conn, cfg.model_name)
+        logger.info(
+            "progress row id=%d resume_cursor=%s",
+            progress_id,
+            cursor_bibcode or "(start)",
+        )
+
+        batches = 0
+        total_updated = 0
+        t_start = time.perf_counter()
+
+        while True:
+            if _STOP:
+                logger.warning("stop signal received — flushing and exiting")
+                break
+            if cfg.max_batches is not None and batches >= cfg.max_batches:
+                logger.info("reached --max-batches=%d, stopping", cfg.max_batches)
+                break
+
+            t_batch = time.perf_counter()
+            updated, new_cursor = _run_batch(
+                conn, cfg.model_name, cursor_bibcode, cfg.batch_size, cfg.dry_run
+            )
+            batch_ms = (time.perf_counter() - t_batch) * 1000.0
+
+            if updated == 0 or new_cursor is None:
+                logger.info("no more rows to backfill")
+                break
+
+            total_updated += updated
+            cursor_bibcode = new_cursor
+            batches += 1
+
+            if not cfg.dry_run:
+                _update_progress(conn, progress_id, new_cursor, updated)
+                conn.commit()
+
+            if batches % 10 == 0 or batches == 1:
+                rate = total_updated / max(1.0, time.perf_counter() - t_start)
+                logger.info(
+                    "batch=%d updated=%d cumulative=%d rate=%.0f rows/s "
+                    "batch_ms=%.0f cursor=%s",
+                    batches,
+                    updated,
+                    total_updated,
+                    rate,
+                    batch_ms,
+                    new_cursor,
+                )
+
+        note = "stopped" if _STOP else "finished"
+        if not cfg.dry_run:
+            _close_progress_row(conn, progress_id, note)
+
+        remaining_after = _count_remaining(conn, cfg.model_name)
+        logger.info(
+            "halfvec backfill %s — updated=%d elapsed=%.1fs remaining=%d",
+            note,
+            total_updated,
+            time.perf_counter() - t_start,
+            remaining_after,
+        )
+    return 0 if not _STOP else 130
+
+
+def parse_args(argv: list[str] | None = None) -> BackfillConfig:
+    p = argparse.ArgumentParser(description="Backfill paper_embeddings.embedding_hv from embedding.")
+    p.add_argument("--dsn", default=os.environ.get("SCIX_DSN", "dbname=scix"))
+    p.add_argument("--model", dest="model_name", default="indus")
+    p.add_argument("--batch-size", type=int, default=20000)
+    p.add_argument("--max-batches", type=int, default=None)
+    p.add_argument("--no-resume", dest="resume", action="store_false", default=True)
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    return BackfillConfig(
+        dsn=args.dsn,
+        model_name=args.model_name,
+        batch_size=args.batch_size,
+        max_batches=args.max_batches,
+        resume=args.resume,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    _install_signal_handler()
+    sys.exit(run(parse_args()))

--- a/scripts/recompute_citation_communities.py
+++ b/scripts/recompute_citation_communities.py
@@ -285,12 +285,26 @@ def run(
             medium: list[int] = []
             fine: list[int] = []
         else:
-            logger.info("Running Leiden (coarse=%.6f)...", resolution_coarse)
-            coarse = compute_leiden(giant, resolution=resolution_coarse, seed=seed)
-            logger.info("Running Leiden (medium=%.6f)...", resolution_medium)
-            medium = compute_leiden(giant, resolution=resolution_medium, seed=seed)
-            logger.info("Running Leiden (fine=%.6f)...", resolution_fine)
-            fine = compute_leiden(giant, resolution=resolution_fine, seed=seed)
+            # CPM (CPMVertexPartition) is the CWTS-recommended quality
+            # function for citation graphs at fine-grained resolutions —
+            # CLAUDE.md specifies 0.001/0.01/0.1 as meaningful CPM edge-
+            # density thresholds. Modularity (the igraph default) is
+            # degenerate at those values because its resolution parameter
+            # shifts the gain function proportionally to the graph's edge
+            # count; at res=0.001 on a 298M-edge graph, modularity collapses
+            # to a single community.
+            logger.info("Running Leiden CPM (coarse=%.6f)...", resolution_coarse)
+            coarse = compute_leiden(
+                giant, resolution=resolution_coarse, seed=seed, partition_type="CPM"
+            )
+            logger.info("Running Leiden CPM (medium=%.6f)...", resolution_medium)
+            medium = compute_leiden(
+                giant, resolution=resolution_medium, seed=seed, partition_type="CPM"
+            )
+            logger.info("Running Leiden CPM (fine=%.6f)...", resolution_fine)
+            fine = compute_leiden(
+                giant, resolution=resolution_fine, seed=seed, partition_type="CPM"
+            )
 
         n_coarse, largest_coarse, coarse_by_bib = _summarize_membership(coarse, giant_i2b)
         n_medium, largest_medium, _ = _summarize_membership(medium, giant_i2b)
@@ -351,7 +365,7 @@ def run(
         "started_at": started_at,
         "git_sha": _git_sha(),
         "seed": seed,
-        "partition_type": "modularity",
+        "partition_type": "CPM",
         "resolutions": {
             "coarse": resolution_coarse,
             "medium": resolution_medium,

--- a/src/scix/embed.py
+++ b/src/scix/embed.py
@@ -186,24 +186,36 @@ def store_embeddings_copy(
     if not inputs:
         return 0
 
+    # INDUS writes land in the halfvec(768) shadow column populated by
+    # the storage/halfvec-migration cutover (bead scix_experiments-0vy).
+    # Pilot models keep using the legacy vector column. The staging table
+    # carries both columns so we only need one COPY path; the INSERT
+    # picks the right target.
+    use_halfvec = model_name == "indus"
+
     with conn.cursor() as cur:
         cur.execute(
             "CREATE TEMP TABLE IF NOT EXISTS _embed_staging ("
-            "  bibcode TEXT, model_name TEXT, embedding vector(768),"
+            "  bibcode TEXT, model_name TEXT,"
+            "  embedding    vector(768),"
+            "  embedding_hv halfvec(768),"
             "  input_type TEXT, source_hash TEXT"
             ") ON COMMIT DELETE ROWS"
         )
 
         with cur.copy(
-            "COPY _embed_staging (bibcode, model_name, embedding, input_type, source_hash) "
+            "COPY _embed_staging "
+            "  (bibcode, model_name, embedding, embedding_hv, input_type, source_hash) "
             "FROM STDIN"
         ) as copy:
             for inp, vec in zip(inputs, vectors):
+                literal = _vec_to_pgvector(vec)
                 copy.write_row(
                     (
                         inp.bibcode,
                         model_name,
-                        _vec_to_pgvector(vec),
+                        None if use_halfvec else literal,
+                        literal if use_halfvec else None,
                         inp.input_type,
                         inp.source_hash,
                     )
@@ -211,13 +223,14 @@ def store_embeddings_copy(
 
         cur.execute(
             "INSERT INTO paper_embeddings "
-            "  (bibcode, model_name, embedding, input_type, source_hash) "
-            "SELECT bibcode, model_name, embedding, input_type, source_hash "
+            "  (bibcode, model_name, embedding, embedding_hv, input_type, source_hash) "
+            "SELECT bibcode, model_name, embedding, embedding_hv, input_type, source_hash "
             "FROM _embed_staging "
             "ON CONFLICT (bibcode, model_name) DO UPDATE SET "
-            "  embedding = EXCLUDED.embedding, "
-            "  input_type = EXCLUDED.input_type, "
-            "  source_hash = EXCLUDED.source_hash"
+            "  embedding    = EXCLUDED.embedding, "
+            "  embedding_hv = EXCLUDED.embedding_hv, "
+            "  input_type   = EXCLUDED.input_type, "
+            "  source_hash  = EXCLUDED.source_hash"
         )
         count = cur.rowcount
 
@@ -239,7 +252,23 @@ def store_embeddings(
         return 0
 
     with conn.cursor() as cur:
+        use_halfvec = model_name == "indus"
         for inp, vec in zip(inputs, vectors):
+            literal = _vec_to_pgvector(vec)
+            if use_halfvec:
+                cur.execute(
+                    """
+                    INSERT INTO paper_embeddings
+                        (bibcode, model_name, embedding_hv, input_type, source_hash)
+                    VALUES (%s, %s, %s::halfvec(768), %s, %s)
+                    ON CONFLICT (bibcode, model_name) DO UPDATE SET
+                        embedding_hv = EXCLUDED.embedding_hv,
+                        input_type   = EXCLUDED.input_type,
+                        source_hash  = EXCLUDED.source_hash
+                    """,
+                    (inp.bibcode, model_name, literal, inp.input_type, inp.source_hash),
+                )
+                continue
             cur.execute(
                 """
                 INSERT INTO paper_embeddings (bibcode, model_name, embedding, input_type, source_hash)

--- a/src/scix/search.py
+++ b/src/scix/search.py
@@ -339,7 +339,13 @@ def vector_search(
 
     ndim = len(query_embedding)
     vec_str = "[" + ",".join(str(v) for v in query_embedding) + "]"
-    vec_cast = f"vector({ndim})"
+    # INDUS (the production dense signal) lives in the halfvec(768) shadow
+    # column backed by idx_embed_hnsw_indus_hv (halfvec_cosine_ops). All
+    # other per-model rows still use the legacy `embedding` column with
+    # vector_cosine_ops — see bead scix_experiments-0vy.
+    use_halfvec = model_name == "indus"
+    vec_col = "pe.embedding_hv" if use_halfvec else "pe.embedding"
+    vec_cast = f"halfvec({ndim})" if use_halfvec else f"vector({ndim})"
     effective = filters or SearchFilters()
     filter_clause, filter_params = effective.to_where_clause("p")
     entity_clause, entity_params = effective.to_entity_filter_clause("p")
@@ -358,17 +364,17 @@ def vector_search(
     if scan_mode is not None:
         iterative_applied = configure_iterative_scan(conn, mode=scan_mode)
 
-    # Cast embedding to vector(N) to match per-model partial HNSW expression
-    # indexes which are defined on (embedding::vector(N)).
+    # Match the per-model partial HNSW expression: halfvec(768) for INDUS,
+    # vector(N) for pilots.
     query = f"""
         SELECT {STUB_COLUMNS},
-               1 - (pe.embedding::{vec_cast} <=> %s::{vec_cast}) AS similarity
+               1 - ({vec_col} <=> %s::{vec_cast}) AS similarity
         FROM paper_embeddings pe
         JOIN papers p ON p.bibcode = pe.bibcode
         WHERE pe.model_name = %s
         {filter_clause}
         {entity_clause}
-        ORDER BY pe.embedding::{vec_cast} <=> %s::{vec_cast}
+        ORDER BY {vec_col} <=> %s::{vec_cast}
         LIMIT %s
     """
     params: list[Any] = [vec_str, model_name] + filter_params + entity_params + [vec_str, limit]
@@ -500,7 +506,9 @@ def _filter_first_vector_search(
 
     ndim = len(query_embedding)
     vec_str = "[" + ",".join(str(v) for v in query_embedding) + "]"
-    vec_cast = f"vector({ndim})"
+    use_halfvec = model_name == "indus"
+    vec_col = "pe.embedding_hv" if use_halfvec else "pe.embedding"
+    vec_cast = f"halfvec({ndim})" if use_halfvec else f"vector({ndim})"
     effective = filters or SearchFilters()
     filter_clause, filter_params = effective.to_where_clause("p")
     entity_clause, entity_params = effective.to_entity_filter_clause("p")
@@ -513,12 +521,12 @@ def _filter_first_vector_search(
             {entity_clause}
         )
         SELECT {STUB_COLUMNS},
-               1 - (pe.embedding::{vec_cast} <=> %s::{vec_cast}) AS similarity
+               1 - ({vec_col} <=> %s::{vec_cast}) AS similarity
         FROM paper_embeddings pe
         JOIN filtered f ON f.bibcode = pe.bibcode
         JOIN papers p   ON p.bibcode = pe.bibcode
         WHERE pe.model_name = %s
-        ORDER BY pe.embedding::{vec_cast} <=> %s::{vec_cast}
+        ORDER BY {vec_col} <=> %s::{vec_cast}
         LIMIT %s
     """
     params: list[Any] = filter_params + entity_params + [vec_str, model_name, vec_str, limit]

--- a/tests/test_halfvec_migration.py
+++ b/tests/test_halfvec_migration.py
@@ -1,0 +1,135 @@
+"""Tests for the halfvec storage migration (bead scix_experiments-0vy).
+
+Two layers:
+
+1. Unit tests (always run) — verify the SQL emitted by search.py and embed.py
+   targets the halfvec shadow column for INDUS and the legacy vector column
+   for pilot models.
+2. Integration tests (skipped without SCIX_TEST_DSN) — apply the migration
+   against a real pgvector-enabled database, seed synthetic rows, run the
+   backfill script, and assert the partial HNSW halfvec index is the one the
+   planner uses.
+
+The integration leg uses SCIX_TEST_DSN to protect production. See
+CLAUDE.md #Testing — Database Safety.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+
+# ---------------------------------------------------------------------------
+# Unit: search.py routes INDUS to embedding_hv + halfvec cast
+# ---------------------------------------------------------------------------
+
+
+def _captured_sql(model_name: str) -> str:
+    from scix.search import vector_search  # local import after sys.path tweak
+
+    conn = MagicMock()
+    # cursor() returns a context manager whose __enter__ is a MagicMock
+    cm = conn.cursor.return_value
+    cm.__enter__.return_value.fetchall.return_value = []
+
+    class _Capture:
+        last_query = ""
+
+        def execute(self, query, params=None):  # noqa: ARG002
+            _Capture.last_query = query
+
+        def fetchall(self):
+            return []
+
+    capture = _Capture()
+    cm.__enter__.return_value = capture
+
+    vector_search(conn, [0.1] * 768, model_name=model_name, limit=5)
+    return capture.last_query
+
+
+def test_indus_query_uses_embedding_hv_and_halfvec_cast() -> None:
+    sql = _captured_sql("indus")
+    assert "pe.embedding_hv" in sql, sql
+    assert "halfvec(768)" in sql, sql
+    assert "pe.embedding::" not in sql, sql
+    assert "vector(768)" not in sql, sql
+
+
+def test_pilot_query_still_uses_legacy_vector_column() -> None:
+    sql = _captured_sql("specter2")
+    assert "pe.embedding" in sql
+    assert "vector(768)" in sql
+    assert "embedding_hv" not in sql
+    assert "halfvec" not in sql
+
+
+# ---------------------------------------------------------------------------
+# Integration: applies migration 053+054 against scix_test
+# ---------------------------------------------------------------------------
+
+
+def _test_dsn() -> str | None:
+    dsn = os.environ.get("SCIX_TEST_DSN")
+    if not dsn:
+        return None
+    if "scix_test" not in dsn:
+        pytest.fail(
+            "SCIX_TEST_DSN must reference scix_test — got: " + dsn,
+            pytrace=False,
+        )
+    return dsn
+
+
+@pytest.mark.integration
+def test_migration_053_054_apply_idempotently() -> None:
+    dsn = _test_dsn()
+    if dsn is None:
+        pytest.skip("SCIX_TEST_DSN not set")
+
+    import psycopg
+
+    for migration in (
+        "migrations/053_paper_embeddings_halfvec.sql",
+        "migrations/054_paper_embeddings_halfvec_index.sql",
+    ):
+        # Apply twice — must succeed both times (IF NOT EXISTS everywhere).
+        for _ in range(2):
+            result = subprocess.run(
+                ["psql", dsn, "-v", "ON_ERROR_STOP=1", "-f", migration],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert result.returncode == 0, (
+                f"{migration} failed: {result.stderr}"
+            )
+
+    with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT format_type(atttypid, atttypmod) "
+            "FROM pg_attribute WHERE attrelid='paper_embeddings'::regclass "
+            "AND attname='embedding_hv'"
+        )
+        row = cur.fetchone()
+        assert row is not None and row[0] == "halfvec(768)", row
+
+        cur.execute(
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE indexname='idx_embed_hnsw_indus_hv'"
+        )
+        idx = cur.fetchone()
+        assert idx is not None
+        assert "halfvec_cosine_ops" in idx[0]
+        assert "model_name = 'indus'" in idx[0]


### PR DESCRIPTION
## Summary

Scaffolds the online (shadow-column) halfvec migration for the 32.4M INDUS
rows in `paper_embeddings`. Bead: `scix_experiments-0vy`.

- `migrations/053_paper_embeddings_halfvec.sql` — add `embedding_hv halfvec(768)` column + `halfvec_backfill_progress` tracking table (metadata-only, idempotent).
- `migrations/054_paper_embeddings_halfvec_index.sql` — `CREATE INDEX CONCURRENTLY idx_embed_hnsw_indus_hv` using `halfvec_cosine_ops` on the shadow column, partial `WHERE model_name='indus'`.
- `scripts/backfill_halfvec.py` — batched, resumable, signal-safe backfill of `embedding_hv` from `embedding` for INDUS rows. `scix-batch` friendly; progress persisted in `halfvec_backfill_progress` so OOM kills don't lose cursor.
- `src/scix/search.py` — `vector_search` + `_filter_first_vector_search` route `model_name='indus'` to `embedding_hv <=> $1::halfvec(768)`; pilots (nomic, specter2) keep using `embedding` + `vector(N)`.
- `src/scix/embed.py` — COPY and INSERT writer paths populate `embedding_hv` for INDUS writes; pilot writes unchanged.
- `docs/runbooks/halfvec_migration.md` — pre-flight checks, 10-phase execution, rollback matrix.
- `tests/test_halfvec_migration.py` — 2 unit tests on emitted SQL (pass); integration leg opt-in via `SCIX_TEST_DSN`.

## Design decision — Option B (shadow column) over Option A (`ALTER TYPE`)

`ALTER COLUMN ... TYPE halfvec(768) USING ...` on 32M rows / 125 GB TOAST holds `ACCESS EXCLUSIVE` for the full multi-hour rewrite, which blocks the daily `scripts/embed.py` cron and gives us no interruption recovery. Shadow column + batched backfill is online, resumable, and trivially rollback-able (don't deploy the code change). Extra TOAST during transition is reclaimed by phase 9 cleanup once the cutover is stable.

## Status

- [x] Migrations apply + re-apply cleanly on `scix_test`.
- [x] Backfill script populates `embedding_hv` on 500 synthetic rows; idempotency verified.
- [x] Planner picks `idx_embed_hnsw_indus_hv` in `EXPLAIN` for INDUS `ORDER BY ... <=> halfvec(768)` queries.
- [x] Unit tests pass.
- [ ] Gated on M3 (`scripts/recompute_citation_communities.py`, PID 174609) finishing — `count(community_id_fine)` must reach ≥19M.
- [ ] Baseline 50-query eval against current `idx_embed_hnsw_indus` (`results/halfvec_migration/baseline.json`).
- [ ] Backfill + CREATE INDEX CONCURRENTLY on prod (under `scix-batch`).
- [ ] Post-migration 50-query eval, verify nDCG@10 within 0.5 pt.
- [ ] Index-size reduction verified ≥40%.

## Test plan

- [ ] `python -m pytest tests/test_halfvec_migration.py -q` — unit tests.
- [ ] `SCIX_TEST_DSN=dbname=scix_test python -m pytest tests/test_halfvec_migration.py -q -m integration` — migration idempotency against a real pgvector database.
- [ ] Runbook phase 2 — baseline eval JSON committed to `results/halfvec_migration/baseline.json`.
- [ ] Runbook phases 3–5 — schema + backfill + index on prod under `scix-batch`.
- [ ] Runbook phase 7 — post eval JSON + paired diff committed to `results/halfvec_migration/post.json`.
- [ ] Runbook phase 8 — `sizes_after.txt` shows ≥40% shrink vs `sizes_before.txt`.

Draft until benchmarks + size numbers land.