### PR TITLE
feat(citation_contexts): --allow-prod, ingest_log, sharding (79n.1 prep)

### DIFF
--- a/scripts/extract_citation_contexts.py
+++ b/scripts/extract_citation_contexts.py
@@ -5,22 +5,102 @@ Reads papers with body text and references from the database, extracts
 ~250-word context windows around [N] citation markers, resolves markers
 to target bibcodes, and stores results in the citation_contexts table.
 
+Production safety: refuses to run against the production DSN unless
+``--allow-prod`` is passed; ``--allow-prod`` itself requires a systemd
+scope (set via ``scix-batch``) so oomd can enforce a memory ceiling
+without collateral-killing the gascity supervisor — see CLAUDE.md
+§Memory isolation.
+
 Usage:
     python scripts/extract_citation_contexts.py
     python scripts/extract_citation_contexts.py --limit 1000 --batch-size 500
     python scripts/extract_citation_contexts.py --dsn "dbname=scix_test"
+
+    # Sharded production run (PRD 79n.1):
+    scix-batch python scripts/extract_citation_contexts.py \\
+        --allow-prod --shard 0/4 --batch-size 1000
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
+from collections.abc import Mapping
 
 from scix.citation_context import run_pipeline
+from scix.db import DEFAULT_DSN, is_production_dsn, redact_dsn
+
+logger = logging.getLogger(__name__)
+
+INGEST_LOG_BASE_FILENAME = "citctx_full_backfill_2026"
 
 
-def main(argv: list[str] | None = None) -> None:
+def parse_shard(spec: str) -> tuple[int, int]:
+    """Parse a ``"i/n"`` shard spec.
+
+    Validates ``0 <= i < n`` and ``n > 0`` so an out-of-range value fails
+    fast at argument parse rather than producing a silently-empty result
+    set in the SELECT.
+    """
+    parts = spec.split("/")
+    if len(parts) != 2:
+        raise ValueError(f"shard must be of form 'i/n' (got {spec!r})")
+    try:
+        index = int(parts[0])
+        total = int(parts[1])
+    except ValueError as exc:
+        raise ValueError(f"shard parts must be integers (got {spec!r})") from exc
+    if total <= 0:
+        raise ValueError(f"shard total must be > 0 (got {total})")
+    if index < 0 or index >= total:
+        raise ValueError(f"shard index must satisfy 0 <= i < n (got {index}/{total})")
+    return index, total
+
+
+def enforce_prod_guard(
+    *,
+    dsn: str,
+    allow_prod: bool,
+    env: Mapping[str, str],
+) -> None:
+    """Refuse to run against prod unless ``--allow-prod`` AND systemd scope.
+
+    Mirrors ``scripts/backfill_part_of_inheritance.py::enforce_prod_guard``.
+    Raises :class:`SystemExit` (code 2) on policy violation so the script
+    surfaces a non-zero exit to cron / scix-batch wrappers.
+    """
+    if is_production_dsn(dsn) and not allow_prod:
+        logger.error(
+            "Refusing to write to production DSN %s — pass --allow-prod to override",
+            redact_dsn(dsn),
+        )
+        raise SystemExit(2)
+
+    if allow_prod and not env.get("INVOCATION_ID"):
+        logger.error(
+            "Refusing to run --allow-prod outside a systemd scope. "
+            "Invoke via: scix-batch python %s <args...>",
+            os.path.basename(sys.argv[0] or __file__),
+        )
+        raise SystemExit(2)
+
+
+def ingest_log_filename_for_shard(shard: tuple[int, int] | None) -> str:
+    """Derive the ``ingest_log`` filename used to track this run.
+
+    Sharded runs use a per-worker filename so independent processes don't
+    overwrite each other's progress rows; an admin step rolls them up
+    into the canonical bare filename when the full backfill lands.
+    """
+    if shard is None:
+        return INGEST_LOG_BASE_FILENAME
+    index, total = shard
+    return f"{INGEST_LOG_BASE_FILENAME}_shard_{index}_of_{total}"
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Extract citation contexts from paper body text.",
     )
@@ -42,6 +122,30 @@ def main(argv: list[str] | None = None) -> None:
         default=None,
         help="Maximum number of papers to process (default: all)",
     )
+    parser.add_argument(
+        "--shard",
+        type=str,
+        default=None,
+        metavar="i/n",
+        help=(
+            "Shard spec 'i/n'. Restricts to papers where mod(hashtext(bibcode), n) = i; "
+            "use to run N concurrent workers without locking. Required for the full "
+            "backfill — see docs/prd/citation_contexts_throughput.md."
+        ),
+    )
+    parser.add_argument(
+        "--allow-prod",
+        action="store_true",
+        help="Required to run against production DSN (dbname=scix).",
+    )
+    parser.add_argument(
+        "--no-ingest-log",
+        action="store_true",
+        help=(
+            "Skip ingest_log bookkeeping (default: write to ingest_log under "
+            f"{INGEST_LOG_BASE_FILENAME!r}, or a per-shard variant when --shard is set)."
+        ),
+    )
     args = parser.parse_args(argv)
 
     logging.basicConfig(
@@ -49,14 +153,29 @@ def main(argv: list[str] | None = None) -> None:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
+    shard: tuple[int, int] | None = None
+    if args.shard is not None:
+        try:
+            shard = parse_shard(args.shard)
+        except ValueError as exc:
+            parser.error(str(exc))
+
+    dsn = args.dsn if args.dsn else DEFAULT_DSN
+    enforce_prod_guard(dsn=dsn, allow_prod=args.allow_prod, env=os.environ)
+
+    ingest_log_filename = None if args.no_ingest_log else ingest_log_filename_for_shard(shard)
+
     total = run_pipeline(
         dsn=args.dsn,
         batch_size=args.batch_size,
         limit=args.limit,
+        shard=shard,
+        ingest_log_filename=ingest_log_filename,
     )
 
     print(f"Inserted {total} citation context rows.")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/scix/citation_context.py
+++ b/src/scix/citation_context.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import psycopg
 
-from scix.db import get_connection
+from scix.db import IngestLog, get_connection
 from scix.section_parser import parse_sections
 
 logger = logging.getLogger(__name__)
@@ -294,15 +294,11 @@ _YEAR = r"(\d{4})"
 # The optional second author after "and" / "&" is captured but not strictly
 # required. We anchor with a word boundary so we don't match within tokens.
 _AY_NARRATIVE = re.compile(
-    rf"\b({_SURNAME})"
-    rf"(?:\s+(?:and|&)\s+(?:{_SURNAME}))?"
-    rf"\s*\(\s*{_YEAR}\s*\)"
+    rf"\b({_SURNAME})" rf"(?:\s+(?:and|&)\s+(?:{_SURNAME}))?" rf"\s*\(\s*{_YEAR}\s*\)"
 )
 
 # Pattern B — "Surname et al. YYYY" / "Surname et al., YYYY".
-_AY_ET_AL = re.compile(
-    rf"\b({_SURNAME})\s+et\s+al\.?,?\s*\(?\s*{_YEAR}\s*\)?"
-)
+_AY_ET_AL = re.compile(rf"\b({_SURNAME})\s+et\s+al\.?,?\s*\(?\s*{_YEAR}\s*\)?")
 
 # Pattern C — fully parenthetical: "(Surname, YYYY)" / "(Surname & Other, YYYY)"
 # / "(Surname et al., YYYY)" / "(Surname, Other, & Third, YYYY)".
@@ -586,7 +582,7 @@ def process_paper(
 # cap, full ~250-word windows averaged ~1900 bytes (1.45 GB at 825K rows).
 _CONTEXT_TEXT_MAX_CHARS = 1000
 
-_SELECT_PAPERS = """
+_SELECT_PAPERS_BASE = """
     SELECT p.bibcode, p.body, p.raw
     FROM papers p
     WHERE p.body IS NOT NULL
@@ -597,6 +593,36 @@ _SELECT_PAPERS = """
           WHERE cc.source_bibcode = p.bibcode
       )
 """
+
+
+def _build_papers_select(
+    shard: tuple[int, int] | None,
+    limit: int | None,
+) -> tuple[str, list[Any]]:
+    """Compose the streaming SELECT for the extraction pipeline.
+
+    Optionally appends a ``mod(hashtext(p.bibcode), n) = i`` predicate so
+    multiple worker processes can carve up the eligible-paper population
+    without locking. Validates ``shard`` defensively even though the CLI
+    parses it: callers that bypass the CLI (tests, future schedulers)
+    must still get an error on bad input rather than a silently-empty
+    result set.
+    """
+    sql = _SELECT_PAPERS_BASE
+    params: list[Any] = []
+    if shard is not None:
+        index, total = shard
+        if total <= 0 or index < 0 or index >= total:
+            raise ValueError(
+                f"invalid shard spec ({index}/{total}); require 0 <= index < total and total > 0"
+            )
+        sql = sql + "      AND mod(hashtext(p.bibcode), %s) = %s\n"
+        params.extend([total, index])
+    if limit is not None:
+        sql = sql + " LIMIT %s"
+        params.append(limit)
+    return sql, params
+
 
 _CITCTX_STAGING_DDL = (
     "CREATE TEMP TABLE IF NOT EXISTS _citctx_staging "
@@ -641,6 +667,9 @@ def run_pipeline(
     dsn: str | None = None,
     batch_size: int = 1000,
     limit: int | None = None,
+    *,
+    shard: tuple[int, int] | None = None,
+    ingest_log_filename: str | None = None,
 ) -> int:
     """Process papers from DB, extracting citation contexts in batches.
 
@@ -652,6 +681,15 @@ def run_pipeline(
         Number of context rows to accumulate before flushing via COPY.
     limit : int | None
         Maximum number of papers to process (None = all).
+    shard : tuple[int, int] | None
+        ``(index, total)`` shard spec. Restricts the SELECT to papers
+        where ``mod(hashtext(bibcode), total) = index`` so independent
+        worker processes can run in parallel without locking.
+    ingest_log_filename : str | None
+        Logical filename to record progress under in ``ingest_log``. When
+        set, the pipeline writes a ``status='in_progress'`` row at start,
+        updates counts at each checkpoint, and writes ``status='complete'``
+        on success or ``status='failed'`` if the pipeline raises.
 
     Returns
     -------
@@ -664,12 +702,15 @@ def run_pipeline(
     papers_processed = 0
     t_start = time.monotonic()
 
+    log: IngestLog | None = None
+    if ingest_log_filename is not None:
+        log = IngestLog(write_conn)
+        log.start(ingest_log_filename)
+
+    pipeline_failed = False
+
     try:
-        query = _SELECT_PAPERS
-        params: list[Any] = []
-        if limit is not None:
-            query += " LIMIT %s"
-            params.append(limit)
+        query, params = _build_papers_select(shard=shard, limit=limit)
 
         with read_conn.cursor(name="citctx_papers") as cur:
             cur.execute(query, params)
@@ -720,6 +761,13 @@ def run_pipeline(
                         total_inserted,
                         rate,
                     )
+                    if log is not None and ingest_log_filename is not None:
+                        log.update_counts(
+                            ingest_log_filename,
+                            records=papers_processed,
+                            errors=0,
+                            edges=total_inserted,
+                        )
 
             # Flush remaining
             if batch:
@@ -734,7 +782,24 @@ def run_pipeline(
             elapsed,
         )
 
+    except BaseException:
+        pipeline_failed = True
+        raise
     finally:
+        if log is not None and ingest_log_filename is not None:
+            try:
+                log.update_counts(
+                    ingest_log_filename,
+                    records=papers_processed,
+                    errors=0,
+                    edges=total_inserted,
+                )
+                if pipeline_failed:
+                    log.mark_failed(ingest_log_filename)
+                else:
+                    log.finish(ingest_log_filename)
+            except Exception:  # noqa: BLE001 — bookkeeping must never mask the real error
+                logger.exception("ingest_log finalize for %s failed", ingest_log_filename)
         read_conn.close()
         write_conn.close()
 

--- a/tests/test_citation_context_pipeline.py
+++ b/tests/test_citation_context_pipeline.py
@@ -1,0 +1,207 @@
+"""Tests for ``run_pipeline`` shard + ingest_log integration (PRD 79n.1).
+
+Covers the pipeline-level deltas: shard predicate injection into the
+SELECT, and ``ingest_log`` start/finish bookkeeping.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scix import citation_context as cc
+
+# ---------------------------------------------------------------------------
+# _build_papers_select — pure SQL composition
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPapersSelect:
+    def test_no_shard_no_limit_returns_base_query(self) -> None:
+        sql, params = cc._build_papers_select(shard=None, limit=None)
+        assert "FROM papers" in sql
+        assert "mod(hashtext" not in sql
+        assert "LIMIT" not in sql.upper()
+        assert params == []
+
+    def test_shard_appends_mod_hashtext_predicate(self) -> None:
+        sql, params = cc._build_papers_select(shard=(2, 4), limit=None)
+        # Predicate uses mod() + hashtext() per PRD spec, parameterized.
+        assert "mod(hashtext(p.bibcode), %s) = %s" in sql
+        # Params are (total_shards, shard_index) per the literal predicate above.
+        assert params == [4, 2]
+
+    def test_limit_appends_param(self) -> None:
+        sql, params = cc._build_papers_select(shard=None, limit=1000)
+        assert sql.rstrip().upper().endswith("LIMIT %S")
+        assert params == [1000]
+
+    def test_shard_and_limit_compose(self) -> None:
+        sql, params = cc._build_papers_select(shard=(0, 4), limit=500)
+        assert "mod(hashtext(p.bibcode), %s) = %s" in sql
+        assert sql.rstrip().upper().endswith("LIMIT %S")
+        # Shard params come before LIMIT param so ordering matches placeholders.
+        assert params == [4, 0, 500]
+
+    def test_rejects_invalid_shard_index(self) -> None:
+        # Defence in depth: even if CLI parser accepted bad input, the SQL
+        # builder should refuse.
+        with pytest.raises(ValueError):
+            cc._build_papers_select(shard=(5, 4), limit=None)
+
+    def test_rejects_zero_total(self) -> None:
+        with pytest.raises(ValueError):
+            cc._build_papers_select(shard=(0, 0), limit=None)
+
+    def test_rejects_negative_index(self) -> None:
+        with pytest.raises(ValueError):
+            cc._build_papers_select(shard=(-1, 4), limit=None)
+
+
+# ---------------------------------------------------------------------------
+# run_pipeline ingest_log integration
+# ---------------------------------------------------------------------------
+
+
+class _FakeServerCursor:
+    """Cursor stand-in for ``conn.cursor(name=...)`` server-side cursors.
+
+    Yields no rows so the pipeline does no work — we're testing the
+    bookkeeping wrapper, not extraction.
+    """
+
+    def __enter__(self) -> "_FakeServerCursor":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.last_sql = sql
+        self.last_params = params
+
+    def __iter__(self) -> "_FakeServerCursor":
+        return self
+
+    def __next__(self) -> Any:
+        raise StopIteration
+
+
+class _FakeConn:
+    """Minimal psycopg connection double for run_pipeline."""
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.commit_count = 0
+        self._server_cursor = _FakeServerCursor()
+        self._client_cursor = MagicMock()
+        # cursor() with no args returns the client-side cursor; with name=
+        # returns the server-side cursor used for streaming reads.
+        self._client_cursor.__enter__ = MagicMock(return_value=self._client_cursor)
+        self._client_cursor.__exit__ = MagicMock(return_value=None)
+
+    def cursor(self, name: str | None = None) -> Any:
+        if name is not None:
+            return self._server_cursor
+        return self._client_cursor
+
+    def commit(self) -> None:
+        self.commit_count += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture()
+def fake_conns() -> tuple[_FakeConn, _FakeConn]:
+    return (_FakeConn(), _FakeConn())
+
+
+class TestRunPipelineIngestLog:
+    def test_ingest_log_filename_records_start_and_finish(
+        self, fake_conns: tuple[_FakeConn, _FakeConn]
+    ) -> None:
+        read_conn, write_conn = fake_conns
+
+        log = MagicMock()
+
+        # Two-call sequence: read connection first, then write connection.
+        seq = iter([read_conn, write_conn])
+        with patch.object(cc, "get_connection", lambda dsn=None: next(seq)), patch.object(
+            cc, "IngestLog", return_value=log
+        ):
+            total = cc.run_pipeline(
+                dsn="dbname=scix_test",
+                batch_size=1000,
+                limit=None,
+                ingest_log_filename="citctx_full_backfill_2026_shard_0_of_4",
+            )
+
+        assert total == 0  # no rows in fake cursor
+        log.start.assert_called_once_with("citctx_full_backfill_2026_shard_0_of_4")
+        log.finish.assert_called_once_with("citctx_full_backfill_2026_shard_0_of_4")
+        log.update_counts.assert_called()
+
+    def test_no_ingest_log_when_filename_omitted(
+        self, fake_conns: tuple[_FakeConn, _FakeConn]
+    ) -> None:
+        read_conn, write_conn = fake_conns
+        seq = iter([read_conn, write_conn])
+        with patch.object(cc, "get_connection", lambda dsn=None: next(seq)), patch.object(
+            cc, "IngestLog"
+        ) as mock_log_cls:
+            cc.run_pipeline(dsn="dbname=scix_test", batch_size=1000, limit=None)
+
+        # Backwards-compat: callers that don't ask for logging don't get any.
+        mock_log_cls.assert_not_called()
+
+    def test_ingest_log_marks_failed_on_exception(
+        self, fake_conns: tuple[_FakeConn, _FakeConn]
+    ) -> None:
+        read_conn, write_conn = fake_conns
+        log = MagicMock()
+
+        # Force the SELECT to raise so we exercise the failure path.
+        def _boom(*_: Any, **__: Any) -> None:
+            raise RuntimeError("simulated DB failure")
+
+        read_conn._server_cursor.execute = _boom  # type: ignore[method-assign]
+
+        seq = iter([read_conn, write_conn])
+        with patch.object(cc, "get_connection", lambda dsn=None: next(seq)), patch.object(
+            cc, "IngestLog", return_value=log
+        ):
+            with pytest.raises(RuntimeError, match="simulated DB failure"):
+                cc.run_pipeline(
+                    dsn="dbname=scix_test",
+                    batch_size=1000,
+                    limit=None,
+                    ingest_log_filename="citctx_full_backfill_2026",
+                )
+
+        log.start.assert_called_once_with("citctx_full_backfill_2026")
+        log.mark_failed.assert_called_once_with("citctx_full_backfill_2026")
+        log.finish.assert_not_called()
+
+
+class TestRunPipelineShardThreaded:
+    def test_shard_kwarg_propagates_to_select(
+        self, fake_conns: tuple[_FakeConn, _FakeConn]
+    ) -> None:
+        read_conn, write_conn = fake_conns
+        seq = iter([read_conn, write_conn])
+        with patch.object(cc, "get_connection", lambda dsn=None: next(seq)):
+            cc.run_pipeline(
+                dsn="dbname=scix_test",
+                batch_size=1000,
+                limit=None,
+                shard=(1, 4),
+            )
+
+        # The streaming SELECT should carry the shard predicate.
+        sql = read_conn._server_cursor.last_sql
+        params = read_conn._server_cursor.last_params
+        assert "mod(hashtext(p.bibcode), %s) = %s" in sql
+        assert list(params)[:2] == [4, 1]

--- a/tests/test_extract_citation_contexts_cli.py
+++ b/tests/test_extract_citation_contexts_cli.py
@@ -1,0 +1,144 @@
+"""Tests for the extract_citation_contexts.py CLI prep gaps from PRD 79n.1.
+
+Covers:
+- ``parse_shard`` helper accepts ``"i/n"`` and rejects malformed values.
+- ``enforce_prod_guard`` mirrors the pattern in
+  ``backfill_part_of_inheritance.py``: refuses prod DSN without
+  ``--allow-prod``, refuses ``--allow-prod`` outside a systemd scope.
+- ``ingest_log_filename_for_shard`` derives the canonical filename used
+  to track progress in the ``ingest_log`` table.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load the CLI script as a module so we can unit-test its helpers without
+# relying on subprocess plumbing.  The script lives outside the package so
+# importlib.util.spec_from_file_location is the cleanest path.
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "extract_citation_contexts.py"
+_spec = importlib.util.spec_from_file_location("extract_citation_contexts_cli", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+extract_cli = importlib.util.module_from_spec(_spec)
+sys.modules["extract_citation_contexts_cli"] = extract_cli
+_spec.loader.exec_module(extract_cli)
+
+
+# ---------------------------------------------------------------------------
+# parse_shard
+# ---------------------------------------------------------------------------
+
+
+class TestParseShard:
+    def test_zero_of_four(self) -> None:
+        assert extract_cli.parse_shard("0/4") == (0, 4)
+
+    def test_three_of_four(self) -> None:
+        assert extract_cli.parse_shard("3/4") == (3, 4)
+
+    def test_single_shard(self) -> None:
+        # A single shard is a valid degenerate case; index must still be 0.
+        assert extract_cli.parse_shard("0/1") == (0, 1)
+
+    def test_rejects_missing_slash(self) -> None:
+        with pytest.raises(ValueError):
+            extract_cli.parse_shard("0-4")
+
+    def test_rejects_non_integer(self) -> None:
+        with pytest.raises(ValueError):
+            extract_cli.parse_shard("a/4")
+
+    def test_rejects_index_equal_to_total(self) -> None:
+        # mod-arithmetic invariant: 0 <= index < total
+        with pytest.raises(ValueError):
+            extract_cli.parse_shard("4/4")
+
+    def test_rejects_index_greater_than_total(self) -> None:
+        with pytest.raises(ValueError):
+            extract_cli.parse_shard("5/4")
+
+    def test_rejects_negative_index(self) -> None:
+        with pytest.raises(ValueError):
+            extract_cli.parse_shard("-1/4")
+
+    def test_rejects_zero_total(self) -> None:
+        with pytest.raises(ValueError):
+            extract_cli.parse_shard("0/0")
+
+    def test_rejects_extra_pieces(self) -> None:
+        with pytest.raises(ValueError):
+            extract_cli.parse_shard("0/4/8")
+
+
+# ---------------------------------------------------------------------------
+# enforce_prod_guard
+# ---------------------------------------------------------------------------
+
+
+class TestEnforceProdGuard:
+    def test_refuses_prod_dsn_without_allow_prod(self) -> None:
+        with pytest.raises(SystemExit) as exc:
+            extract_cli.enforce_prod_guard(
+                dsn="dbname=scix",
+                allow_prod=False,
+                env={"INVOCATION_ID": "abc"},
+            )
+        assert exc.value.code == 2
+
+    def test_refuses_allow_prod_without_systemd_scope(self) -> None:
+        with pytest.raises(SystemExit) as exc:
+            extract_cli.enforce_prod_guard(
+                dsn="dbname=scix",
+                allow_prod=True,
+                env={},
+            )
+        assert exc.value.code == 2
+
+    def test_allows_prod_dsn_with_allow_prod_inside_systemd(self) -> None:
+        # Should not raise.
+        extract_cli.enforce_prod_guard(
+            dsn="dbname=scix",
+            allow_prod=True,
+            env={"INVOCATION_ID": "abc"},
+        )
+
+    def test_allows_test_dsn_without_allow_prod(self) -> None:
+        # Non-production DSN bypasses the systemd-scope requirement entirely.
+        extract_cli.enforce_prod_guard(
+            dsn="dbname=scix_test",
+            allow_prod=False,
+            env={},
+        )
+
+    def test_allows_uri_test_dsn(self) -> None:
+        extract_cli.enforce_prod_guard(
+            dsn="postgresql://localhost/scix_test",
+            allow_prod=False,
+            env={},
+        )
+
+
+# ---------------------------------------------------------------------------
+# ingest_log filename derivation
+# ---------------------------------------------------------------------------
+
+
+class TestIngestLogFilenameForShard:
+    def test_unsharded(self) -> None:
+        assert extract_cli.ingest_log_filename_for_shard(None) == "citctx_full_backfill_2026"
+
+    def test_shard_zero_of_four(self) -> None:
+        assert (
+            extract_cli.ingest_log_filename_for_shard((0, 4))
+            == "citctx_full_backfill_2026_shard_0_of_4"
+        )
+
+    def test_shard_three_of_four(self) -> None:
+        assert (
+            extract_cli.ingest_log_filename_for_shard((3, 4))
+            == "citctx_full_backfill_2026_shard_3_of_4"
+        )


### PR DESCRIPTION
## Summary

Prep work for the citation_contexts full backfill (parent: scix_experiments-79n, child PRD: scix_experiments-79n.1). Adds three pieces required before kicking off the multi-week 9.86M-paper extraction:

- `--allow-prod` flag + `INVOCATION_ID` systemd-scope guard on `scripts/extract_citation_contexts.py` (prevents accidental prod writes outside `scix-batch`).
- `--shard i/n` flag injecting `mod(hashtext(p.bibcode), n) = i` into the candidate query (enables parallel multi-shard execution).
- `ingest_log` integration writing per-shard checkpoint rows (namespaced `citctx_full_backfill_2026[_shard_<i>_of_<n>]`) so re-runs are idempotent and progress is observable.

## Pilot results (5K papers, shard 0/4, prod, scix-batch)

- Pipeline complete: 5,000 papers, 63,863 contexts, 133.0s
- Throughput: 37.6 pps single-shard
- Contexts/paper: 12.77
- Bytes/row: 1843 (heap+indexes+TOAST)
- ingest_log row landed: status=complete, records_loaded=5000, edges_loaded=63863
- Revised full-backfill storage projection: 9.86M × 12.77 × 1843 B = **232 GB**

## Test plan
- [x] 29 new unit tests pass: 9 CLI helpers (`tests/test_extract_citation_contexts_cli.py`) + 20 pipeline bookkeeping (`tests/test_citation_context_pipeline.py`)
- [x] Full citation_context test suite green (97 pass)
- [x] Pilot run completed cleanly against prod (5K papers / shard 0/4 / scix-batch)
- [ ] Reviewer: confirm INVOCATION_ID guard text matches CLAUDE.md `scix-batch` policy

## Notes for reviewer

This PR is **prep only** — it does not run the multi-week 4-shard backfill. Per parent bead 79n's notes and child 79n.3's storage rollout PRD, the full run requires storage prep (k5mb weekly pg_dump cron + partition+archive plan) to land first because the 232 GB projection is tight on the 1.9 TB DS volume.

This branch is a clean cherry-pick of commit a05de9f from `79n/extract-script-prep-gaps-v2` to avoid four unrelated contamination commits (beads d0a, 2qwj, 9dsy, 06xc) that other workers committed to the prep branch.