### PR TITLE
feat(entity): default fuzzy fallback + trgm index for resolver (dbl.8)

### DIFF
--- a/migrations/063_entities_canonical_name_trgm.sql
+++ b/migrations/063_entities_canonical_name_trgm.sql
@@ -1,0 +1,66 @@
+-- migration: 063_entities_canonical_name_trgm — pg_trgm GIN on entities.canonical_name
+--
+-- Bead: scix_experiments-dbl.8
+--
+-- Problem: EntityResolver._match_fuzzy() does
+--     similarity(lower(canonical_name), lower($1)) > $2
+-- which forces a Seq Scan over the 19M-row entities table (~40s p50 measured
+-- on prod 2026-04-29). That made fuzzy resolve unusable as a default
+-- fallback in the entity tool.
+--
+-- This migration installs the pg_trgm extension (no-op if already present)
+-- and creates a GIN trigram index on lower(canonical_name) so the resolver
+-- can use the index-aware `%` operator and pull only matching rows. The
+-- companion code change (src/scix/entity_resolver.py) switches the WHERE
+-- clause from a similarity()-only filter to a `%`-then-similarity() pair;
+-- the planner uses gin_trgm_ops via the index, then similarity() is
+-- computed only on the candidate set for ranking.
+--
+-- CREATE INDEX CONCURRENTLY cannot run inside a transaction, so this file
+-- has no BEGIN/COMMIT — the psql runner must execute statements in
+-- autocommit. Apply with:
+--
+--     scix-batch --mem-high 4G --mem-max 8G \
+--         psql "$SCIX_DSN" -v ON_ERROR_STOP=1 \
+--             -f migrations/063_entities_canonical_name_trgm.sql
+--
+-- Runtime / resources (estimate, prod 2026-04-29):
+--   - Source: 19,347,591 rows × avg ~22 chars canonical_name → ~2.7 GB heap.
+--   - Build time: ~10-25 minutes wall clock with 4 parallel workers.
+--   - Peak RAM: ~3-6 GB (parallel workers × maintenance_work_mem).
+--   - Disk: ~1.5-3 GB GIN trigram index.
+--
+-- If CREATE INDEX CONCURRENTLY fails midway, the index is left INVALID.
+-- Drop it and retry:
+--     DROP INDEX CONCURRENTLY IF EXISTS idx_entities_canonical_trgm;
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+SET maintenance_work_mem = '2GB';
+SET max_parallel_maintenance_workers = 4;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_entities_canonical_trgm
+    ON entities USING gin (lower(canonical_name) gin_trgm_ops);
+
+-- The schema_migrations row insert lives in its own transaction so the file
+-- can run with statements in autocommit. The CONCURRENTLY index above and
+-- this INSERT are independent — re-running this migration after the index
+-- already exists is a no-op for both.
+INSERT INTO schema_migrations (version, filename)
+    VALUES (63, '063_entities_canonical_name_trgm.sql')
+    ON CONFLICT (version) DO NOTHING;
+
+-- Post-verification:
+--     SELECT indexname, pg_size_pretty(pg_relation_size(indexname::regclass))
+--       FROM pg_indexes
+--      WHERE tablename='entities'
+--        AND indexname='idx_entities_canonical_trgm';
+--
+--     EXPLAIN (ANALYZE) SELECT id, canonical_name,
+--         similarity(lower(canonical_name), 'scibert') AS sim
+--       FROM entities
+--      WHERE lower(canonical_name) % 'scibert'
+--        AND similarity(lower(canonical_name), 'scibert') > 0.3
+--      ORDER BY sim DESC LIMIT 20;
+--
+-- Expected: Bitmap Index Scan on idx_entities_canonical_trgm, sub-second.

--- a/src/scix/entity_resolver.py
+++ b/src/scix/entity_resolver.py
@@ -1,8 +1,24 @@
 """Entity resolver: resolve text mentions to canonical entities.
 
-Queries the normalized entity graph (migration 021) using a cascade of
-match strategies: exact canonical name, alias, external identifier, and
-optional fuzzy matching via pg_trgm.
+Queries the normalized entity graph (migration 021) using a documented
+fallback cascade:
+
+    1. exact_canonical    — entities.canonical_name (case-insensitive)
+    2. alias              — entity_aliases.alias    (case-insensitive)
+    3. identifier         — entity_identifiers.external_id (Q-IDs, DOIs, …)
+    4. fuzzy              — pg_trgm similarity on canonical_name
+                            (auto fallback; uses idx_entities_canonical_trgm
+                             via the `%` operator — migration 063)
+
+Steps 1-3 are tried in order; step 4 fires only when 1-3 produced no
+candidates so the chain has clear precedence and never returns fuzzy
+noise alongside an exact match. All steps return discipline metadata
+on every candidate so callers can filter cross-discipline results
+without a follow-up lookup.
+
+Callers that want the legacy "exact-only" behaviour pass ``fuzzy=False``;
+the default is now ``fuzzy=True`` because empty results were a silent
+failure mode for non-astro queries (bead scix_experiments-dbl.8).
 """
 
 from __future__ import annotations
@@ -16,6 +32,11 @@ from psycopg.rows import dict_row
 logger = logging.getLogger(__name__)
 
 MATCH_METHODS = frozenset({"exact_canonical", "alias", "identifier", "fuzzy"})
+
+# Cap the number of fuzzy candidates returned to the caller. The GIN trigram
+# index can match thousands of rows for a short token; keeping the top-N by
+# similarity is sufficient for disambiguation and avoids unbounded payloads.
+DEFAULT_FUZZY_LIMIT = 20
 
 
 @dataclass(frozen=True)
@@ -34,11 +55,14 @@ class EntityCandidate:
 class EntityResolver:
     """Resolve text mentions to canonical entities in the entity graph.
 
-    Resolution cascade:
-    1. Exact canonical name match (confidence 1.0)
-    2. Alias lookup (confidence 0.9)
-    3. External identifier lookup (confidence 0.85)
-    4. Optional fuzzy match via pg_trgm (confidence = similarity score)
+    Resolution cascade (see module docstring for the full chain):
+        1. Exact canonical name match     (confidence 1.0)
+        2. Alias lookup                   (confidence 0.9)
+        3. External identifier lookup     (confidence 0.85)
+        4. Fuzzy match via pg_trgm        (confidence = similarity score)
+
+    Steps 1-3 short-circuit on first match; step 4 is the final fallback
+    and runs only when 1-3 returned nothing.
     """
 
     def __init__(self, conn: psycopg.Connection) -> None:
@@ -49,38 +73,52 @@ class EntityResolver:
         mention: str,
         *,
         discipline: str | None = None,
-        fuzzy: bool = False,
+        fuzzy: bool = True,
         fuzzy_threshold: float = 0.3,
+        fuzzy_limit: int = DEFAULT_FUZZY_LIMIT,
     ) -> list[EntityCandidate]:
         """Resolve a single mention to a list of entity candidates.
 
         Args:
             mention: Text mention to resolve.
             discipline: Optional discipline for ranking boost (+0.05).
-            fuzzy: Enable pg_trgm fuzzy fallback.
+                Does NOT filter — discipline is informational on every
+                candidate so callers can choose across disciplines.
+            fuzzy: Enable pg_trgm fuzzy fallback. Default True; pass
+                False to suppress fuzzy and get only exact matches.
             fuzzy_threshold: Minimum similarity for fuzzy matches.
+            fuzzy_limit: Maximum number of fuzzy candidates to return.
 
         Returns:
             List of EntityCandidate sorted by confidence DESC,
-            canonical_name ASC. Never limited to one result.
+            canonical_name ASC. Never limited to a single result.
+            Empty list if nothing matches in any stage of the cascade —
+            callers should treat empty as "register this entity" rather
+            than "this entity does not exist".
         """
         candidates: list[EntityCandidate] = []
 
-        # Step 1: Exact canonical name match
+        # Step 1: Exact canonical name match.
         candidates.extend(self._match_canonical(mention))
 
-        # Step 2: Alias match (only if no exact canonical match)
+        # Step 2: Alias match (only if no exact canonical match).
         if not candidates:
             candidates.extend(self._match_alias(mention))
 
-        # Step 3: Identifier match (always — may add new entities)
+        # Step 3: Identifier match (always — may add new entities, e.g.
+        # when a Wikidata Q-ID also happens to be an alias).
         candidates.extend(self._match_identifier(mention))
 
-        # Step 4: Fuzzy fallback (only if enabled and no results yet)
+        # Step 4: Fuzzy fallback. Auto-fires when nothing else matched so
+        # the resolver doesn't silently return empty for capitalisation /
+        # punctuation variants ('alpha-fold' vs 'AlphaFold').
         if fuzzy and not candidates:
-            candidates.extend(self._match_fuzzy(mention, fuzzy_threshold))
+            candidates.extend(
+                self._match_fuzzy(mention, fuzzy_threshold, fuzzy_limit)
+            )
 
-        # Apply discipline boost
+        # Apply discipline boost — purely informational on candidates
+        # whose discipline matches; never used to filter.
         if discipline is not None:
             candidates = [
                 EntityCandidate(
@@ -99,10 +137,10 @@ class EntityResolver:
                 for c in candidates
             ]
 
-        # Deduplicate by entity_id, keeping highest confidence
+        # Deduplicate by entity_id, keeping highest confidence.
         candidates = _deduplicate(candidates)
 
-        # Sort by confidence DESC, then canonical_name ASC
+        # Sort by confidence DESC, then canonical_name ASC.
         candidates.sort(key=lambda c: (-c.confidence, c.canonical_name))
 
         return candidates
@@ -112,8 +150,9 @@ class EntityResolver:
         mentions: list[str],
         *,
         discipline: str | None = None,
-        fuzzy: bool = False,
+        fuzzy: bool = True,
         fuzzy_threshold: float = 0.3,
+        fuzzy_limit: int = DEFAULT_FUZZY_LIMIT,
     ) -> dict[str, list[EntityCandidate]]:
         """Resolve multiple mentions. Returns dict mapping mention to candidates."""
         return {
@@ -122,6 +161,7 @@ class EntityResolver:
                 discipline=discipline,
                 fuzzy=fuzzy,
                 fuzzy_threshold=fuzzy_threshold,
+                fuzzy_limit=fuzzy_limit,
             )
             for mention in mentions
         }
@@ -204,20 +244,36 @@ class EntityResolver:
                 for row in cur.fetchall()
             ]
 
-    def _match_fuzzy(self, mention: str, threshold: float) -> list[EntityCandidate]:
-        """Fuzzy match via pg_trgm similarity on canonical_name."""
+    def _match_fuzzy(
+        self,
+        mention: str,
+        threshold: float,
+        limit: int = DEFAULT_FUZZY_LIMIT,
+    ) -> list[EntityCandidate]:
+        """Fuzzy match via pg_trgm similarity on canonical_name.
+
+        The ``%`` operator is the index-able predicate: it triggers a
+        Bitmap Index Scan on idx_entities_canonical_trgm (migration 063)
+        using the pg_trgm default similarity GUC (0.3). The
+        ``similarity() > threshold`` clause re-filters those candidates
+        when the caller wants a stricter threshold than the GUC. With
+        the index in place a 19M-row resolve drops from ~40s p50 to
+        sub-second; without the index the `%` operator falls back to a
+        Seq Scan with the same semantics, so this code path stays
+        functional during a partially-applied migration.
+        """
         with self._conn.cursor(row_factory=dict_row) as cur:
             cur.execute(
                 """
-                SELECT id, canonical_name, entity_type, source, discipline, sim
-                FROM (
-                    SELECT id, canonical_name, entity_type, source, discipline,
-                           similarity(lower(canonical_name), lower(%(mention)s)) AS sim
-                    FROM entities
-                ) sub
-                WHERE sim > %(threshold)s
+                SELECT id, canonical_name, entity_type, source, discipline,
+                       similarity(lower(canonical_name), lower(%(mention)s)) AS sim
+                FROM entities
+                WHERE lower(canonical_name) %% lower(%(mention)s)
+                  AND similarity(lower(canonical_name), lower(%(mention)s)) > %(threshold)s
+                ORDER BY sim DESC, canonical_name ASC
+                LIMIT %(limit)s
                 """,
-                {"mention": mention, "threshold": threshold},
+                {"mention": mention, "threshold": threshold, "limit": limit},
             )
             return [
                 EntityCandidate(

--- a/src/scix/mcp_server.py
+++ b/src/scix/mcp_server.py
@@ -1871,7 +1871,20 @@ def create_server(_run_self_test: bool = True):
                             "enum": ["search", "resolve", "papers"],
                             "description": (
                                 "resolve: text mention -> canonical entity records "
-                                "(cross-discipline disambiguation). "
+                                "(cross-discipline disambiguation). Walks a four-stage "
+                                "fallback chain so a non-canonical mention does not "
+                                "silently return empty: "
+                                "(1) exact canonical name match, "
+                                "(2) alias lookup if (1) is empty, "
+                                "(3) external identifier match (always tried — Q-IDs, "
+                                "DOIs, etc.), "
+                                "(4) fuzzy pg_trgm similarity if (1)-(3) are all empty. "
+                                "When even fuzzy matches nothing the response includes "
+                                "match_status='no_match' and a suggestion that the "
+                                "entity be registered, so callers can act on the gap "
+                                "instead of silently dropping it. Each candidate carries "
+                                "its discipline so the caller can filter cross-discipline "
+                                "results without an extra round-trip. "
                                 "papers: entity_id (or auto-resolved query) -> "
                                 "papers tagged with that entity via "
                                 "document_entities. "
@@ -1915,8 +1928,15 @@ def create_server(_run_self_test: bool = True):
                         },
                         "fuzzy": {
                             "type": "boolean",
-                            "default": False,
-                            "description": "Enable fuzzy matching (resolve only)",
+                            "default": True,
+                            "description": (
+                                "Enable fuzzy pg_trgm fallback for action='resolve' "
+                                "when canonical/alias/identifier all miss. Default "
+                                "True (auto-fallback chain — bead "
+                                "scix_experiments-dbl.8). Pass False to suppress "
+                                "the fuzzy stage and keep responses to exact "
+                                "matches only."
+                            ),
                         },
                         "limit": {"type": "integer", "default": 20},
                         "min_confidence_tier": {
@@ -4037,10 +4057,13 @@ def _handle_entity(conn: psycopg.Connection, args: dict[str, Any]) -> str:
 
     if action == "resolve":
         resolver = EntityResolver(conn)
+        # dbl.8: fuzzy defaults to True so the resolver auto-falls-through
+        # canonical -> alias -> identifier -> fuzzy. Callers that want only
+        # exact matches can opt out with fuzzy=False.
         candidates = resolver.resolve(
             query.strip(),
             discipline=args.get("discipline"),
-            fuzzy=args.get("fuzzy", False),
+            fuzzy=args.get("fuzzy", True),
         )
         # eq95: drop denylisted (canonical_name, entity_type) pairs so
         # noisy generic-word entities ('data'/'dataset', 'method'/'method',
@@ -4049,27 +4072,38 @@ def _handle_entity(conn: psycopg.Connection, args: dict[str, Any]) -> str:
         from scix.extract.ner_denylist import is_denylisted as _is_denylisted
 
         candidates = [c for c in candidates if not _is_denylisted(c.canonical_name, c.entity_type)]
-        result_json = json.dumps(
-            {
-                "query": query.strip(),
-                "candidates": [
-                    {
-                        "entity_id": c.entity_id,
-                        "canonical_name": c.canonical_name,
-                        "entity_type": c.entity_type,
-                        "source": c.source,
-                        "discipline": c.discipline,
-                        "confidence": c.confidence,
-                        "match_method": c.match_method,
-                    }
-                    for c in candidates
-                ],
-                "total": len(candidates),
-            },
-            indent=2,
-            default=str,
-        )
-        return _inject_coverage_note(result_json)
+        # dbl.8: surface a clear no-match signal instead of returning a
+        # silent empty list. Empty `candidates` after the full cascade
+        # means the entity is genuinely unknown to SciX — agents need
+        # this distinction to decide whether to give up or trigger an
+        # entity-registration follow-up.
+        match_status = candidates[0].match_method if candidates else "no_match"
+        payload: dict[str, Any] = {
+            "query": query.strip(),
+            "candidates": [
+                {
+                    "entity_id": c.entity_id,
+                    "canonical_name": c.canonical_name,
+                    "entity_type": c.entity_type,
+                    "source": c.source,
+                    "discipline": c.discipline,
+                    "confidence": c.confidence,
+                    "match_method": c.match_method,
+                }
+                for c in candidates
+            ],
+            "total": len(candidates),
+            "match_status": match_status,
+        }
+        if not candidates:
+            payload["suggestion"] = (
+                f"No match for {query.strip()!r} in the entity registry "
+                f"after canonical/alias/identifier/fuzzy fallback. "
+                f"Either the mention is a typo or the entity has not been "
+                f"harvested yet — consider filing a registration request "
+                f"(see docs/mcp_tool_audit_2026-04.md §entity-registration)."
+            )
+        return _inject_coverage_note(json.dumps(payload, indent=2, default=str))
 
     if action == "search":
         # mh14: legacy extraction-row kinds (negative_result, quant_claim)

--- a/src/scix/mcp_server.py
+++ b/src/scix/mcp_server.py
@@ -4099,9 +4099,10 @@ def _handle_entity(conn: psycopg.Connection, args: dict[str, Any]) -> str:
             payload["suggestion"] = (
                 f"No match for {query.strip()!r} in the entity registry "
                 f"after canonical/alias/identifier/fuzzy fallback. "
-                f"Either the mention is a typo or the entity has not been "
-                f"harvested yet — consider filing a registration request "
-                f"(see docs/mcp_tool_audit_2026-04.md §entity-registration)."
+                f"The mention is either a typo or the entity has not been "
+                f"harvested yet — consider filing an entity-registration "
+                f"request (bead epic scix_experiments-dbl) so the gap is "
+                f"tracked rather than silently swallowed."
             )
         return _inject_coverage_note(json.dumps(payload, indent=2, default=str))
 

--- a/tests/test_entity_resolver.py
+++ b/tests/test_entity_resolver.py
@@ -267,7 +267,7 @@ class TestIdentifierMatch:
 
 
 class TestFuzzyMatch:
-    """resolve() with fuzzy=True falls back to pg_trgm similarity."""
+    """resolve() falls back to pg_trgm similarity by default (bead dbl.8)."""
 
     def test_fuzzy_fallback(self) -> None:
         conn = _make_mock_conn(
@@ -316,8 +316,10 @@ class TestFuzzyMatch:
         # Should only have the exact match, fuzzy not triggered
         assert all(r.match_method == "exact_canonical" for r in results)
 
-    def test_fuzzy_disabled_by_default(self) -> None:
-        """Without fuzzy=True, no fuzzy results even if no other matches."""
+    def test_fuzzy_enabled_by_default(self) -> None:
+        """Without an explicit flag, fuzzy fires automatically when nothing
+        else matches (bead dbl.8: stop returning silent empties for
+        non-canonical mentions)."""
         conn = _make_mock_conn(
             {
                 "lower(canonical_name) = lower": [],
@@ -330,7 +332,71 @@ class TestFuzzyMatch:
         )
         resolver = EntityResolver(conn)
         results = resolver.resolve("Benu")
+        assert len(results) == 1
+        assert results[0].match_method == "fuzzy"
+        assert results[0].canonical_name == "Bennu"
+
+    def test_fuzzy_can_be_explicitly_disabled(self) -> None:
+        """Callers that want exact-only matching pass fuzzy=False."""
+        conn = _make_mock_conn(
+            {
+                "lower(canonical_name) = lower": [],
+                "FROM entity_aliases": [],
+                "FROM entity_identifiers": [],
+                "similarity": [
+                    _entity_row(id=10, canonical_name="Bennu", sim=0.65),
+                ],
+            }
+        )
+        resolver = EntityResolver(conn)
+        results = resolver.resolve("Benu", fuzzy=False)
         assert results == []
+
+    def test_fuzzy_uses_index_friendly_operator(self) -> None:
+        """The fuzzy SQL uses the `%` operator so the planner can hit
+        idx_entities_canonical_trgm (migration 063) instead of the
+        Seq-Scan-only similarity()-in-WHERE pattern."""
+        conn = _make_mock_conn(
+            {
+                "similarity": [
+                    _entity_row(id=10, canonical_name="Bennu", sim=0.65),
+                ],
+            }
+        )
+        resolver = EntityResolver(conn)
+        resolver.resolve("Benu")
+        cursor = conn.cursor.return_value
+        last_sql = getattr(cursor, "_last_sql", "")
+        # The canonical_name % $1 predicate is what makes the GIN trigram
+        # index usable; without it we regress to the 19M-row Seq Scan.
+        assert "%" in last_sql
+        assert "LIMIT" in last_sql
+
+    def test_fuzzy_returns_discipline(self) -> None:
+        """Fuzzy candidates carry their discipline tag so callers can
+        filter cross-discipline results without an extra round-trip."""
+        conn = _make_mock_conn(
+            {
+                "lower(canonical_name) = lower": [],
+                "FROM entity_aliases": [],
+                "FROM entity_identifiers": [],
+                "similarity": [
+                    _entity_row(
+                        id=10, canonical_name="SciBERT",
+                        discipline="cs", sim=0.95,
+                    ),
+                    _entity_row(
+                        id=20, canonical_name="MatSciBERT",
+                        discipline="materials", sim=0.55,
+                    ),
+                ],
+            }
+        )
+        resolver = EntityResolver(conn)
+        results = resolver.resolve("SciBert")
+        assert len(results) == 2
+        disciplines = {r.discipline for r in results}
+        assert disciplines == {"cs", "materials"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_paper_tools.py
+++ b/tests/test_mcp_paper_tools.py
@@ -799,7 +799,10 @@ class TestDispatchResolveEntity:
         assert result["candidates"][0]["canonical_name"] == "OSIRIS-REx"
         assert result["candidates"][0]["confidence"] == 1.0
         assert result["candidates"][0]["match_method"] == "exact_canonical"
-        mock_instance.resolve.assert_called_once_with("OSIRIS-REx", discipline=None, fuzzy=False)
+        # dbl.8: resolve defaults to fuzzy=True so the cascade auto-falls
+        # through canonical -> alias -> identifier -> fuzzy. Callers
+        # (including legacy resolve_entity) inherit this default.
+        mock_instance.resolve.assert_called_once_with("OSIRIS-REx", discipline=None, fuzzy=True)
 
     @patch("scix.mcp_server.EntityResolver")
     def test_dispatch_with_discipline(self, MockResolver: MagicMock) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -351,7 +351,7 @@ class TestEntityTool:
         mock_candidate.source = "metadata"
         mock_candidate.discipline = "astronomy"
         mock_candidate.confidence = 0.95
-        mock_candidate.match_method = "exact"
+        mock_candidate.match_method = "exact_canonical"
         mock_resolver.resolve.return_value = [mock_candidate]
         mock_resolver_cls.return_value = mock_resolver
 
@@ -361,6 +361,91 @@ class TestEntityTool:
         )
         assert result["total"] == 1
         assert result["candidates"][0]["canonical_name"] == "James Webb Space Telescope"
+        # dbl.8: match_status mirrors the top-candidate match_method so the
+        # caller sees which stage of the cascade produced the answer.
+        assert result["match_status"] == "exact_canonical"
+        assert "suggestion" not in result
+
+    @patch("scix.mcp_server.EntityResolver")
+    def test_entity_resolve_defaults_fuzzy_on(
+        self, mock_resolver_cls: MagicMock
+    ) -> None:
+        """dbl.8: the MCP entity tool defaults action='resolve' to fuzzy=True
+        so non-canonical mentions do not silently return empty."""
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.return_value = []
+        mock_resolver_cls.return_value = mock_resolver
+
+        conn = MagicMock()
+        _dispatch_tool(conn, "entity", {"action": "resolve", "query": "alpha-fold"})
+
+        # The dispatch layer never passes fuzzy=False unless the caller
+        # explicitly asked for it, so the resolver call should see the
+        # default-on flag.
+        _, kwargs = mock_resolver.resolve.call_args
+        assert kwargs.get("fuzzy") is True
+
+    @patch("scix.mcp_server.EntityResolver")
+    def test_entity_resolve_no_match_suggests_registration(
+        self, mock_resolver_cls: MagicMock
+    ) -> None:
+        """dbl.8: surface a clear no-match signal when the cascade returns
+        empty so callers can act on the gap instead of silently dropping
+        the query."""
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.return_value = []
+        mock_resolver_cls.return_value = mock_resolver
+
+        conn = MagicMock()
+        result = json.loads(
+            _dispatch_tool(
+                conn,
+                "entity",
+                {"action": "resolve", "query": "TotallyMadeUpEntity12345"},
+            )
+        )
+        assert result["total"] == 0
+        assert result["candidates"] == []
+        assert result["match_status"] == "no_match"
+        # The suggestion text mentions the cascade so an agent can recover
+        # in one turn (e.g. file an entity-registration request).
+        assert "suggestion" in result
+        suggestion = result["suggestion"].lower()
+        assert "register" in suggestion or "registration" in suggestion
+        assert "TotallyMadeUpEntity12345" in result["suggestion"]
+
+    @patch("scix.mcp_server.EntityResolver")
+    def test_entity_resolve_match_status_reflects_top_candidate(
+        self, mock_resolver_cls: MagicMock
+    ) -> None:
+        """dbl.8: match_status surfaces which stage of the cascade resolved
+        the top candidate so callers can tell a confident exact match
+        apart from a low-confidence fuzzy fallback without inspecting
+        every candidate."""
+        from scix.entity_resolver import EntityCandidate
+
+        mock_resolver = MagicMock()
+        mock_resolver.resolve.return_value = [
+            EntityCandidate(
+                entity_id=10,
+                canonical_name="Bennu",
+                entity_type="target",
+                source="physh",
+                discipline="planetary",
+                confidence=0.65,
+                match_method="fuzzy",
+            )
+        ]
+        mock_resolver_cls.return_value = mock_resolver
+
+        conn = MagicMock()
+        result = json.loads(
+            _dispatch_tool(conn, "entity", {"action": "resolve", "query": "Benu"})
+        )
+        assert result["match_status"] == "fuzzy"
+        # discipline is preserved on the candidate so cross-discipline
+        # filtering works without a follow-up call.
+        assert result["candidates"][0]["discipline"] == "planetary"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bead: [scix_experiments-dbl.8](../) — child of cross-discipline epic dbl.

The entity tool's `action='resolve'` was returning silent empties for non-canonical
mentions ('alpha-fold' → no match, even though 'AlphaFold' is in the registry) because
fuzzy fallback was opt-in. This PR makes the fallback chain run automatically and
surfaces a clear no-match suggestion when even fuzzy fails.

- **`EntityResolver.resolve` defaults `fuzzy=True`** so the cascade
  `canonical → alias → identifier → fuzzy` auto-fires.
- **MCP `entity` tool**:
  - `action='resolve'` defaults `fuzzy=True` (was `False`).
  - Response carries `match_status` echoing the top-candidate `match_method`.
  - On full-cascade miss, response includes a `suggestion` string pointing at the
    parent epic so the gap is tracked rather than silently swallowed.
  - Tool description documents the four-stage chain so an agent picks `resolve`
    correctly without reading the source.
- **Migration 063** adds a `pg_trgm` GIN index on `lower(canonical_name)` so the
  fuzzy lookup uses a Bitmap Index Scan instead of a 19M-row Seq Scan.
  Build is `CONCURRENTLY` (~10–25 min on prod). Code path stays correct without
  the index — `%` falls back to a sequential scan with the same semantics.
- Discipline is already on every `EntityCandidate`; the docstring now reaffirms
  the contract for cross-discipline filtering.

## Verification

Smoke run against prod (`dbname=scix`, before index marked valid):

```text
exact: AlphaFold        match_status=exact_canonical, total=1
fuzzy: alpha-fold       match_status=fuzzy,           total=20, top=AlphaFold (sim 0.615)
miss : NotARealEntity   match_status=no_match,        total=0,  suggestion present
```

After `migration 063` lands the GIN index becomes `indisvalid=true` and the
fuzzy planner switches to a Bitmap Index Scan; today the long-running
investigation snapshot keeps the index in `indisready/!indisvalid` state — it
will validate as soon as that backend finishes.

## Test plan

- [x] `tests/test_entity_resolver.py` — 25 passing (5 new tests covering
      default-on fuzzy, opt-out, index-friendly SQL, discipline echo, no-match)
- [x] `tests/test_mcp_server.py` — 71 passing (3 new tests covering match_status,
      suggestion, default fuzzy in dispatch)
- [x] `tests/test_mcp_paper_tools.py` — updated `test_dispatch_exact_match` for
      the new fuzzy default; full file passes
- [x] Live integration smoke against `dbname=scix` on the three acceptance
      cases (`AlphaFold`, `alpha-fold`, `NotARealEntity12345`)
- [ ] Migration 063 applied on prod (build complete, awaiting `indisvalid=true`
      after long-running snapshot finishes)

## Acceptance criteria (from the bead)

- ✅ entity.resolve has documented fallback chain: canonical exact → alias exact → fuzzy → empty-with-suggestion
- ✅ Test: `resolve('AlphaFold')` returns non-empty today; `resolve('SciBERT')` and `resolve('MatSciBERT')` will return non-empty once dbl S3+S4 harvest those entities
- ✅ Returns include `discipline` so agents can filter